### PR TITLE
I861 SalesPerson at Retail doc

### DIFF
--- a/IRP/.settings/Default.cset
+++ b/IRP/.settings/Default.cset
@@ -1,10 +1,82 @@
 {
   "version": 1,
   "settings": {
-    "structure-consructor-too-many-keys": {
+    "right-interactive-open-external-data-processors": {
+      "enabled": false
+    },
+    "module-accessibility-at-client": {
+      "enabled": false
+    },
+    "right-administration": {
       "enabled": false
     },
     "common-module-type": {
+      "enabled": false
+    },
+    "right-configuration-extensions-administration": {
+      "enabled": false
+    },
+    "right-start-automation": {
+      "enabled": false
+    },
+    "right-interactive-delete": {
+      "enabled": false
+    },
+    "right-view-event-log": {
+      "enabled": false
+    },
+    "right-data-administration": {
+      "enabled": false
+    },
+    "right-interactive-clear-deletion-mark-predefined-data": {
+      "enabled": false
+    },
+    "right-interactive-delete-predefined-data": {
+      "enabled": false
+    },
+    "right-start-external-connection": {
+      "enabled": false
+    },
+    "role-right-has-rls": {
+      "enabled": false
+    },
+    "right-interactive-delete-marked-predefined-data": {
+      "enabled": false
+    },
+    "right-start-thin-client": {
+      "enabled": false
+    },
+    "right-active-users": {
+      "enabled": false
+    },
+    "structure-consructor-too-many-keys": {
+      "enabled": false
+    },
+    "right-interactive-set-deletion-mark-predefined-data": {
+      "enabled": false
+    },
+    "right-exclusive-mode": {
+      "enabled": false
+    },
+    "right-output-to-printer-file-clipboard": {
+      "enabled": false
+    },
+    "right-update-database-configuration": {
+      "enabled": false
+    },
+    "right-start-thick-client": {
+      "enabled": false
+    },
+    "right-all-functions-mode": {
+      "enabled": false
+    },
+    "right-start-web-client": {
+      "enabled": false
+    },
+    "right-interactive-open-external-reports": {
+      "enabled": false
+    },
+    "right-save-user-data": {
       "enabled": false
     }
   }

--- a/IRP/src/AccumulationRegisters/R2050T_RetailSales/R2050T_RetailSales.mdo
+++ b/IRP/src/AccumulationRegisters/R2050T_RetailSales/R2050T_RetailSales.mdo
@@ -111,6 +111,25 @@
     <fullTextSearch>Use</fullTextSearch>
     <useInTotals>true</useInTotals>
   </dimensions>
+  <dimensions uuid="388bd086-38c2-4122-98b5-4386e7eddc4d">
+    <name>SalesPerson</name>
+    <synonym>
+      <key>en</key>
+      <value>Sales person</value>
+    </synonym>
+    <type>
+      <types>CatalogRef.Partners</types>
+    </type>
+    <minValue xsi:type="core:UndefinedValue"/>
+    <maxValue xsi:type="core:UndefinedValue"/>
+    <choiceParameters>
+      <name>Filter.Employee</name>
+      <value xsi:type="core:BooleanValue">
+        <value>true</value>
+      </value>
+    </choiceParameters>
+    <fullTextSearch>Use</fullTextSearch>
+  </dimensions>
   <dimensions uuid="955df867-20b9-4eb7-a510-be4e2533a072">
     <name>RetailSalesReceipt</name>
     <synonym>

--- a/IRP/src/AccumulationRegisters/R2050T_RetailSales/R2050T_RetailSales.mdo
+++ b/IRP/src/AccumulationRegisters/R2050T_RetailSales/R2050T_RetailSales.mdo
@@ -129,6 +129,7 @@
       </value>
     </choiceParameters>
     <fullTextSearch>Use</fullTextSearch>
+    <useInTotals>true</useInTotals>
   </dimensions>
   <dimensions uuid="955df867-20b9-4eb7-a510-be4e2533a072">
     <name>RetailSalesReceipt</name>

--- a/IRP/src/Configuration/Configuration.mdo
+++ b/IRP/src/Configuration/Configuration.mdo
@@ -719,6 +719,7 @@
   <informationRegisters>InformationRegister.TaxSettings</informationRegisters>
   <informationRegisters>InformationRegister.UserSettings</informationRegisters>
   <informationRegisters>InformationRegister.T3010S_RowIDInfo</informationRegisters>
+  <informationRegisters>InformationRegister.RetailWorkers</informationRegisters>
   <accumulationRegisters>AccumulationRegister.CashInTransit</accumulationRegisters>
   <accumulationRegisters>AccumulationRegister.R1001T_Purchases</accumulationRegisters>
   <accumulationRegisters>AccumulationRegister.R1002T_PurchaseReturns</accumulationRegisters>

--- a/IRP/src/DataProcessors/PointOfSale/Forms/Form/Form.form
+++ b/IRP/src/DataProcessors/PointOfSale/Forms/Form/Form.form
@@ -195,7 +195,6 @@
               <autoMaxHeight>true</autoMaxHeight>
               <groupVerticalAlign>Center</groupVerticalAlign>
               <placementArea>UserCmds</placementArea>
-              <toolTipRepresentation>Auto</toolTipRepresentation>
               <representationInContextMenu>Auto</representationInContextMenu>
               <shapeRepresentation>None</shapeRepresentation>
             </items>
@@ -833,6 +832,56 @@
                     </extInfo>
                   </items>
                   <items xsi:type="form:FormField">
+                    <name>ItemListSalesPerson</name>
+                    <id>1015</id>
+                    <visible>true</visible>
+                    <enabled>true</enabled>
+                    <userVisible>
+                      <common>true</common>
+                    </userVisible>
+                    <dataPath xsi:type="form:DataPath">
+                      <segments>Object.ItemList.SalesPerson</segments>
+                    </dataPath>
+                    <extendedTooltip>
+                      <name>ItemListSalesPersonExtendedTooltip</name>
+                      <id>1017</id>
+                      <visible>true</visible>
+                      <enabled>true</enabled>
+                      <userVisible>
+                        <common>true</common>
+                      </userVisible>
+                      <type>Label</type>
+                      <autoMaxWidth>true</autoMaxWidth>
+                      <autoMaxHeight>true</autoMaxHeight>
+                      <extInfo xsi:type="form:LabelDecorationExtInfo">
+                        <horizontalAlign>Left</horizontalAlign>
+                      </extInfo>
+                    </extendedTooltip>
+                    <contextMenu>
+                      <name>ItemListSalesPersonContextMenu</name>
+                      <id>1016</id>
+                      <visible>true</visible>
+                      <enabled>true</enabled>
+                      <userVisible>
+                        <common>true</common>
+                      </userVisible>
+                      <autoFill>true</autoFill>
+                    </contextMenu>
+                    <type>InputField</type>
+                    <editMode>Enter</editMode>
+                    <showInHeader>true</showInHeader>
+                    <headerHorizontalAlign>Left</headerHorizontalAlign>
+                    <showInFooter>true</showInFooter>
+                    <extInfo xsi:type="form:InputFieldExtInfo">
+                      <autoMaxWidth>true</autoMaxWidth>
+                      <autoMaxHeight>true</autoMaxHeight>
+                      <wrap>true</wrap>
+                      <chooseType>true</chooseType>
+                      <typeDomainEnabled>true</typeDomainEnabled>
+                      <textEdit>true</textEdit>
+                    </extInfo>
+                  </items>
+                  <items xsi:type="form:FormField">
                     <name>ItemListKey</name>
                     <id>800</id>
                     <enabled>true</enabled>
@@ -1365,7 +1414,6 @@
                       <autoMaxWidth>true</autoMaxWidth>
                       <autoMaxHeight>true</autoMaxHeight>
                       <placementArea>UserCmds</placementArea>
-                      <toolTipRepresentation>Auto</toolTipRepresentation>
                       <representationInContextMenu>Auto</representationInContextMenu>
                     </items>
                     <visible>true</visible>
@@ -3115,7 +3163,6 @@
           <font xsi:type="core:FontDef">
             <height>20.0</height>
           </font>
-          <toolTipRepresentation>Auto</toolTipRepresentation>
           <representationInContextMenu>Auto</representationInContextMenu>
         </items>
         <visible>true</visible>
@@ -3293,7 +3340,6 @@
             <height>4</height>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
             <locationInCommandBar>InCommandBar</locationInCommandBar>
           </items>
@@ -3331,7 +3377,6 @@
             <picture xsi:type="core:PictureRef">
               <picture>CommonPicture.Share</picture>
             </picture>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -3367,7 +3412,6 @@
             <backColor xsi:type="core:ColorRef">
               <color>Web.Ivory</color>
             </backColor>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -3403,7 +3447,6 @@
             <backColor xsi:type="core:ColorRef">
               <color>Web.Azure</color>
             </backColor>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -3437,7 +3480,39 @@
             <height>4</height>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
+            <representationInContextMenu>Auto</representationInContextMenu>
+          </items>
+          <items xsi:type="form:Button">
+            <name>SetSalesPerson</name>
+            <id>1013</id>
+            <visible>true</visible>
+            <enabled>true</enabled>
+            <userVisible>
+              <common>true</common>
+            </userVisible>
+            <extendedTooltip>
+              <name>SetSalesPersonExtendedTooltip</name>
+              <id>1014</id>
+              <visible>true</visible>
+              <enabled>true</enabled>
+              <userVisible>
+                <common>true</common>
+              </userVisible>
+              <type>Label</type>
+              <autoMaxWidth>true</autoMaxWidth>
+              <autoMaxHeight>true</autoMaxHeight>
+              <extInfo xsi:type="form:LabelDecorationExtInfo">
+                <horizontalAlign>Left</horizontalAlign>
+              </extInfo>
+            </extendedTooltip>
+            <type>UsualButton</type>
+            <commandName>Form.Command.SetSalesPerson</commandName>
+            <representation>Auto</representation>
+            <width>10</width>
+            <autoMaxWidth>true</autoMaxWidth>
+            <height>4</height>
+            <autoMaxHeight>true</autoMaxHeight>
+            <placementArea>UserCmds</placementArea>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <visible>true</visible>
@@ -3503,7 +3578,6 @@
             <height>4</height>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -3537,7 +3611,6 @@
             <height>4</height>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -3573,7 +3646,6 @@
             <backColor xsi:type="core:ColorRef">
               <color>Web.Azure</color>
             </backColor>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -3610,7 +3682,6 @@
             <backColor xsi:type="core:ColorRef">
               <color>Web.Cream</color>
             </backColor>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -3646,7 +3717,6 @@
             <backColor xsi:type="core:ColorRef">
               <color>Web.Beige</color>
             </backColor>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <visible>true</visible>
@@ -3787,7 +3857,6 @@
           <height>12.0</height>
           <bold>true</bold>
         </font>
-        <toolTipRepresentation>Auto</toolTipRepresentation>
         <representationInContextMenu>Auto</representationInContextMenu>
       </items>
       <visible>true</visible>
@@ -4780,6 +4849,23 @@ WHERE
       <itemValueType/>
     </extInfo>
   </attributes>
+  <attributes>
+    <name>SalesPersonByDefault</name>
+    <title>
+      <key>en</key>
+      <value>Sales person by default</value>
+    </title>
+    <id>176</id>
+    <valueType>
+      <types>CatalogRef.Partners</types>
+    </valueType>
+    <view>
+      <common>true</common>
+    </view>
+    <edit>
+      <common>true</common>
+    </edit>
+  </attributes>
   <formCommands>
     <name>qPayment</name>
     <title>
@@ -5079,6 +5165,23 @@ document</value>
       </handler>
     </action>
     <representation>Text</representation>
+    <currentRowUse>Auto</currentRowUse>
+  </formCommands>
+  <formCommands>
+    <name>SetSalesPerson</name>
+    <title>
+      <key>en</key>
+      <value>Set sales person</value>
+    </title>
+    <id>22</id>
+    <use>
+      <common>true</common>
+    </use>
+    <action xsi:type="form:FormCommandHandlerContainer">
+      <handler>
+        <name>SetSalesPerson</name>
+      </handler>
+    </action>
     <currentRowUse>Auto</currentRowUse>
   </formCommands>
   <commandInterface>

--- a/IRP/src/Documents/RetailReturnReceipt/Forms/DocumentForm/Form.form
+++ b/IRP/src/Documents/RetailReturnReceipt/Forms/DocumentForm/Form.form
@@ -1890,6 +1890,56 @@
           </extInfo>
         </items>
         <items xsi:type="form:FormField">
+          <name>ItemListSalesPerson</name>
+          <id>642</id>
+          <visible>true</visible>
+          <enabled>true</enabled>
+          <userVisible>
+            <common>true</common>
+          </userVisible>
+          <dataPath xsi:type="form:DataPath">
+            <segments>Object.ItemList.SalesPerson</segments>
+          </dataPath>
+          <extendedTooltip>
+            <name>ItemListSalesPersonExtendedTooltip</name>
+            <id>644</id>
+            <visible>true</visible>
+            <enabled>true</enabled>
+            <userVisible>
+              <common>true</common>
+            </userVisible>
+            <type>Label</type>
+            <autoMaxWidth>true</autoMaxWidth>
+            <autoMaxHeight>true</autoMaxHeight>
+            <extInfo xsi:type="form:LabelDecorationExtInfo">
+              <horizontalAlign>Left</horizontalAlign>
+            </extInfo>
+          </extendedTooltip>
+          <contextMenu>
+            <name>ItemListSalesPersonContextMenu</name>
+            <id>643</id>
+            <visible>true</visible>
+            <enabled>true</enabled>
+            <userVisible>
+              <common>true</common>
+            </userVisible>
+            <autoFill>true</autoFill>
+          </contextMenu>
+          <type>InputField</type>
+          <editMode>Enter</editMode>
+          <showInHeader>true</showInHeader>
+          <headerHorizontalAlign>Left</headerHorizontalAlign>
+          <showInFooter>true</showInFooter>
+          <extInfo xsi:type="form:InputFieldExtInfo">
+            <autoMaxWidth>true</autoMaxWidth>
+            <autoMaxHeight>true</autoMaxHeight>
+            <wrap>true</wrap>
+            <chooseType>true</chooseType>
+            <typeDomainEnabled>true</typeDomainEnabled>
+            <textEdit>true</textEdit>
+          </extInfo>
+        </items>
+        <items xsi:type="form:FormField">
           <name>ItemListStore</name>
           <id>72</id>
           <visible>true</visible>
@@ -2282,7 +2332,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -2313,7 +2362,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -2345,7 +2393,6 @@
             <height>1</height>
             <maxHeight>1</maxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -2377,7 +2424,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -2408,7 +2454,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -2439,7 +2484,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -2664,7 +2708,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <visible>true</visible>
@@ -5836,7 +5879,6 @@
       <autoMaxWidth>true</autoMaxWidth>
       <autoMaxHeight>true</autoMaxHeight>
       <placementArea>UserCmds</placementArea>
-      <toolTipRepresentation>Auto</toolTipRepresentation>
       <representationInContextMenu>Auto</representationInContextMenu>
       <locationInCommandBar>InAdditionalSubmenu</locationInCommandBar>
     </items>

--- a/IRP/src/Documents/RetailReturnReceipt/ManagerModule.bsl
+++ b/IRP/src/Documents/RetailReturnReceipt/ManagerModule.bsl
@@ -117,7 +117,7 @@ Function GetQueryTextsSecondaryTables()
 	QueryArray = New Array();
 	QueryArray.Add(ItemList());
 	QueryArray.Add(Payments());
-	QueryArray.Add(RetailSales());
+	QueryArray.Add(RetailReturn());
 	QueryArray.Add(OffersInfo());
 	QueryArray.Add(SerialLotNumbers());
 	QueryArray.Add(PostingServer.Exists_R4011B_FreeStocks());
@@ -253,96 +253,95 @@ Function OffersInfo()
 		   |		ON RetailReturnReceiptItemList.Key = TableRowIDInfo.Key";
 EndFunction
 
-Function RetailSales()
+Function RetailReturn()
 	Return "SELECT
-		   |	RetailReturnReceiptItemList.Ref.Branch AS Branch,
-		   |	RetailReturnReceiptItemList.Ref.Company AS Company,
-		   |	RetailReturnReceiptItemList.ItemKey AS ItemKey,
-		   |	SUM(RetailReturnReceiptItemList.QuantityInBaseUnit) AS Quantity,
-		   |	SUM(ISNULL(RetailReturnReceiptSerialLotNumbers.Quantity, 0)) AS QuantityBySerialLtNumbers,
-		   |	RetailReturnReceiptItemList.Ref.Date AS Period,
-		   |	CASE
-		   |		WHEN RetailReturnReceiptItemList.RetailSalesReceipt = VALUE(Document.RetailSalesReceipt.EmptyRef)
-		   |			THEN RetailReturnReceiptItemList.Ref
-		   |		ELSE RetailReturnReceiptItemList.RetailSalesReceipt
-		   |	END AS RetailSalesReceipt,
-		   |	SUM(RetailReturnReceiptItemList.TotalAmount) AS Amount,
-		   |	SUM(RetailReturnReceiptItemList.NetAmount) AS NetAmount,
-		   |	SUM(RetailReturnReceiptItemList.OffersAmount) AS OffersAmount,
-		   |	RetailReturnReceiptItemList.Key AS RowKey,
-		   |	RetailReturnReceiptSerialLotNumbers.SerialLotNumber AS SerialLotNumber,
-		   |	RetailReturnReceiptItemList.Store
-		   |INTO tmpRetailSales
-		   |FROM
-		   |	Document.RetailReturnReceipt.ItemList AS RetailReturnReceiptItemList
-		   |		LEFT JOIN Document.RetailReturnReceipt.SerialLotNumbers AS RetailReturnReceiptSerialLotNumbers
-		   |		ON RetailReturnReceiptItemList.Key = RetailReturnReceiptSerialLotNumbers.Key
-		   |		AND RetailReturnReceiptItemList.Ref = RetailReturnReceiptSerialLotNumbers.Ref
-		   |		AND RetailReturnReceiptItemList.Ref = &Ref
-		   |		AND RetailReturnReceiptSerialLotNumbers.Ref = &Ref
-		   |WHERE
-		   |	RetailReturnReceiptItemList.Ref = &Ref
-		   |GROUP BY
-		   |	RetailReturnReceiptItemList.Ref.Branch,
-		   |	RetailReturnReceiptItemList.Ref.Company,
-		   |	RetailReturnReceiptItemList.ItemKey,
-		   |	RetailReturnReceiptItemList.Ref.Date,
-		   |	CASE
-		   |		WHEN RetailReturnReceiptItemList.RetailSalesReceipt = VALUE(Document.RetailSalesReceipt.EmptyRef)
-		   |			THEN RetailReturnReceiptItemList.Ref
-		   |		ELSE RetailReturnReceiptItemList.RetailSalesReceipt
-		   |	END,
-		   |	RetailReturnReceiptItemList.Key,
-		   |	RetailReturnReceiptSerialLotNumbers.SerialLotNumber,
-		   |	RetailReturnReceiptItemList.Store
-		   |;
-		   |
-		   |
-		   |////////////////////////////////////////////////////////////////////////////////
-		   |SELECT
-		   |	tmpRetailSales.Company AS Company,
-		   |	tmpRetailSales.Branch AS Branch,
-		   |	tmpRetailSales.ItemKey AS ItemKey,
-		   |	CASE
-		   |		WHEN tmpRetailSales.QuantityBySerialLtNumbers = 0
-		   |			THEN -tmpRetailSales.Quantity
-		   |		ELSE -tmpRetailSales.QuantityBySerialLtNumbers
-		   |	END AS Quantity,
-		   |	tmpRetailSales.Period AS Period,
-		   |	tmpRetailSales.RetailSalesReceipt AS RetailSalesReceipt,
-		   |	tmpRetailSales.RowKey AS RowKey,
-		   |	tmpRetailSales.SerialLotNumber AS SerialLotNumber,
-		   |	CASE
-		   |		WHEN tmpRetailSales.QuantityBySerialLtNumbers <> 0
-		   |			THEN CASE
-		   |				WHEN tmpRetailSales.Quantity = 0
-		   |					THEN 0
-		   |				ELSE -tmpRetailSales.Amount / tmpRetailSales.Quantity * tmpRetailSales.QuantityBySerialLtNumbers
-		   |			END
-		   |		ELSE tmpRetailSales.Amount
-		   |	END AS Amount,
-		   |	CASE
-		   |		WHEN tmpRetailSales.QuantityBySerialLtNumbers <> 0
-		   |			THEN CASE
-		   |				WHEN tmpRetailSales.Quantity = 0
-		   |					THEN 0
-		   |				ELSE -tmpRetailSales.NetAmount / tmpRetailSales.Quantity * tmpRetailSales.QuantityBySerialLtNumbers
-		   |			END
-		   |		ELSE tmpRetailSales.NetAmount
-		   |	END AS NetAmount,
-		   |	CASE
-		   |		WHEN tmpRetailSales.QuantityBySerialLtNumbers <> 0
-		   |			THEN CASE
-		   |				WHEN tmpRetailSales.Quantity = 0
-		   |					THEN 0
-		   |				ELSE -tmpRetailSales.OffersAmount / tmpRetailSales.Quantity * tmpRetailSales.QuantityBySerialLtNumbers
-		   |			END
-		   |		ELSE tmpRetailSales.OffersAmount
-		   |	END AS OffersAmount,
-		   |	tmpRetailSales.Store
-		   |INTO RetailSales
-		   |FROM
-		   |	tmpRetailSales AS tmpRetailSales";
+	|	RetailReturnReceiptItemList.Ref.Branch AS Branch,
+	|	RetailReturnReceiptItemList.Ref.Company AS Company,
+	|	RetailReturnReceiptItemList.ItemKey AS ItemKey,
+	|	SUM(RetailReturnReceiptItemList.QuantityInBaseUnit) AS Quantity,
+	|	SUM(ISNULL(RetailReturnReceiptSerialLotNumbers.Quantity, 0)) AS QuantityBySerialLtNumbers,
+	|	RetailReturnReceiptItemList.Ref.Date AS Period,
+	|	CASE
+	|		WHEN RetailReturnReceiptItemList.RetailSalesReceipt = VALUE(Document.RetailSalesReceipt.EmptyRef)
+	|			THEN RetailReturnReceiptItemList.Ref
+	|		ELSE RetailReturnReceiptItemList.RetailSalesReceipt
+	|	END AS RetailSalesReceipt,
+	|	SUM(RetailReturnReceiptItemList.TotalAmount) AS Amount,
+	|	SUM(RetailReturnReceiptItemList.NetAmount) AS NetAmount,
+	|	SUM(RetailReturnReceiptItemList.OffersAmount) AS OffersAmount,
+	|	RetailReturnReceiptItemList.Key AS RowKey,
+	|	RetailReturnReceiptSerialLotNumbers.SerialLotNumber AS SerialLotNumber,
+	|	RetailReturnReceiptItemList.Store
+	|INTO tmpRetailReturn
+	|FROM
+	|	Document.RetailReturnReceipt.ItemList AS RetailReturnReceiptItemList
+	|		LEFT JOIN Document.RetailReturnReceipt.SerialLotNumbers AS RetailReturnReceiptSerialLotNumbers
+	|		ON RetailReturnReceiptItemList.Key = RetailReturnReceiptSerialLotNumbers.Key
+	|		AND RetailReturnReceiptItemList.Ref = RetailReturnReceiptSerialLotNumbers.Ref
+	|		AND RetailReturnReceiptItemList.Ref = &Ref
+	|		AND RetailReturnReceiptSerialLotNumbers.Ref = &Ref
+	|WHERE
+	|	RetailReturnReceiptItemList.Ref = &Ref
+	|GROUP BY
+	|	RetailReturnReceiptItemList.Ref.Branch,
+	|	RetailReturnReceiptItemList.Ref.Company,
+	|	RetailReturnReceiptItemList.ItemKey,
+	|	RetailReturnReceiptItemList.Ref.Date,
+	|	CASE
+	|		WHEN RetailReturnReceiptItemList.RetailSalesReceipt = VALUE(Document.RetailSalesReceipt.EmptyRef)
+	|			THEN RetailReturnReceiptItemList.Ref
+	|		ELSE RetailReturnReceiptItemList.RetailSalesReceipt
+	|	END,
+	|	RetailReturnReceiptItemList.Key,
+	|	RetailReturnReceiptSerialLotNumbers.SerialLotNumber,
+	|	RetailReturnReceiptItemList.Store
+	|;
+	|
+	|////////////////////////////////////////////////////////////////////////////////
+	|SELECT
+	|	tmpRetailReturn.Company AS Company,
+	|	tmpRetailReturn.Branch AS Branch,
+	|	tmpRetailReturn.ItemKey AS ItemKey,
+	|	CASE
+	|		WHEN tmpRetailReturn.QuantityBySerialLtNumbers = 0
+	|			THEN -tmpRetailReturn.Quantity
+	|		ELSE -tmpRetailReturn.QuantityBySerialLtNumbers
+	|	END AS Quantity,
+	|	tmpRetailReturn.Period AS Period,
+	|	tmpRetailReturn.RetailSalesReceipt AS RetailSalesReceipt,
+	|	tmpRetailReturn.RowKey AS RowKey,
+	|	tmpRetailReturn.SerialLotNumber AS SerialLotNumber,
+	|	CASE
+	|		WHEN tmpRetailReturn.QuantityBySerialLtNumbers <> 0
+	|			THEN CASE
+	|				WHEN tmpRetailReturn.Quantity = 0
+	|					THEN 0
+	|				ELSE -tmpRetailReturn.Amount / tmpRetailReturn.Quantity * tmpRetailReturn.QuantityBySerialLtNumbers
+	|			END
+	|		ELSE tmpRetailReturn.Amount
+	|	END AS Amount,
+	|	CASE
+	|		WHEN tmpRetailReturn.QuantityBySerialLtNumbers <> 0
+	|			THEN CASE
+	|				WHEN tmpRetailReturn.Quantity = 0
+	|					THEN 0
+	|				ELSE -tmpRetailReturn.NetAmount / tmpRetailReturn.Quantity * tmpRetailReturn.QuantityBySerialLtNumbers
+	|			END
+	|		ELSE tmpRetailReturn.NetAmount
+	|	END AS NetAmount,
+	|	CASE
+	|		WHEN tmpRetailReturn.QuantityBySerialLtNumbers <> 0
+	|			THEN CASE
+	|				WHEN tmpRetailReturn.Quantity = 0
+	|					THEN 0
+	|				ELSE -tmpRetailReturn.OffersAmount / tmpRetailReturn.Quantity * tmpRetailReturn.QuantityBySerialLtNumbers
+	|			END
+	|		ELSE tmpRetailReturn.OffersAmount
+	|	END AS OffersAmount,
+	|	tmpRetailReturn.Store
+	|INTO RetailReturn
+	|FROM
+	|	tmpRetailReturn AS tmpRetailReturn";
 EndFunction
 
 Function SerialLotNumbers()
@@ -450,7 +449,7 @@ Function R2050T_RetailSales()
 		   |	*
 		   |INTO R2050T_RetailSales
 		   |FROM
-		   |	RetailSales AS RetailSales
+		   |	RetailReturn AS RetailReturn
 		   |WHERE
 		   |	TRUE";
 EndFunction

--- a/IRP/src/Documents/RetailReturnReceipt/RetailReturnReceipt.mdo
+++ b/IRP/src/Documents/RetailReturnReceipt/RetailReturnReceipt.mdo
@@ -622,6 +622,26 @@
       <maxValue xsi:type="core:UndefinedValue"/>
       <fullTextSearch>Use</fullTextSearch>
     </attributes>
+    <attributes uuid="eb3fdcb2-82bb-4e46-aee9-31e98585ac55">
+      <name>SalesPerson</name>
+      <synonym>
+        <key>en</key>
+        <value>Sales person</value>
+      </synonym>
+      <type>
+        <types>CatalogRef.Partners</types>
+      </type>
+      <minValue xsi:type="core:UndefinedValue"/>
+      <maxValue xsi:type="core:UndefinedValue"/>
+      <choiceParameters>
+        <name>Filter.Employee</name>
+        <value xsi:type="core:BooleanValue">
+          <value>true</value>
+        </value>
+      </choiceParameters>
+      <dataHistory>Use</dataHistory>
+      <fullTextSearch>Use</fullTextSearch>
+    </attributes>
   </tabularSections>
   <tabularSections uuid="9060cdbb-b372-4def-9d82-0080fe8c5522">
     <producedTypes>

--- a/IRP/src/Documents/RetailSalesReceipt/Forms/DocumentForm/Form.form
+++ b/IRP/src/Documents/RetailSalesReceipt/Forms/DocumentForm/Form.form
@@ -1944,6 +1944,56 @@
           </extInfo>
         </items>
         <items xsi:type="form:FormField">
+          <name>ItemListSalesPerson</name>
+          <id>1061</id>
+          <visible>true</visible>
+          <enabled>true</enabled>
+          <userVisible>
+            <common>true</common>
+          </userVisible>
+          <dataPath xsi:type="form:DataPath">
+            <segments>Object.ItemList.SalesPerson</segments>
+          </dataPath>
+          <extendedTooltip>
+            <name>ItemListSalesPersonExtendedTooltip</name>
+            <id>1063</id>
+            <visible>true</visible>
+            <enabled>true</enabled>
+            <userVisible>
+              <common>true</common>
+            </userVisible>
+            <type>Label</type>
+            <autoMaxWidth>true</autoMaxWidth>
+            <autoMaxHeight>true</autoMaxHeight>
+            <extInfo xsi:type="form:LabelDecorationExtInfo">
+              <horizontalAlign>Left</horizontalAlign>
+            </extInfo>
+          </extendedTooltip>
+          <contextMenu>
+            <name>ItemListSalesPersonContextMenu</name>
+            <id>1062</id>
+            <visible>true</visible>
+            <enabled>true</enabled>
+            <userVisible>
+              <common>true</common>
+            </userVisible>
+            <autoFill>true</autoFill>
+          </contextMenu>
+          <type>InputField</type>
+          <editMode>Enter</editMode>
+          <showInHeader>true</showInHeader>
+          <headerHorizontalAlign>Left</headerHorizontalAlign>
+          <showInFooter>true</showInFooter>
+          <extInfo xsi:type="form:InputFieldExtInfo">
+            <autoMaxWidth>true</autoMaxWidth>
+            <autoMaxHeight>true</autoMaxHeight>
+            <wrap>true</wrap>
+            <chooseType>true</chooseType>
+            <typeDomainEnabled>true</typeDomainEnabled>
+            <textEdit>true</textEdit>
+          </extInfo>
+        </items>
+        <items xsi:type="form:FormField">
           <name>ItemListStore</name>
           <id>267</id>
           <visible>true</visible>
@@ -2377,7 +2427,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -2408,7 +2457,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -2439,7 +2487,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <maxHeight>1</maxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -2471,7 +2518,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <items xsi:type="form:Button">
@@ -2696,7 +2742,6 @@
             <autoMaxWidth>true</autoMaxWidth>
             <autoMaxHeight>true</autoMaxHeight>
             <placementArea>UserCmds</placementArea>
-            <toolTipRepresentation>Auto</toolTipRepresentation>
             <representationInContextMenu>Auto</representationInContextMenu>
           </items>
           <visible>true</visible>
@@ -6132,7 +6177,6 @@
       <autoMaxWidth>true</autoMaxWidth>
       <autoMaxHeight>true</autoMaxHeight>
       <placementArea>UserCmds</placementArea>
-      <toolTipRepresentation>Auto</toolTipRepresentation>
       <representationInContextMenu>Auto</representationInContextMenu>
       <locationInCommandBar>InAdditionalSubmenu</locationInCommandBar>
     </items>

--- a/IRP/src/Documents/RetailSalesReceipt/ManagerModule.bsl
+++ b/IRP/src/Documents/RetailSalesReceipt/ManagerModule.bsl
@@ -221,85 +221,87 @@ EndFunction
 
 Function RetailSales()
 	Return "SELECT
-		   |	RetailSalesReceiptItemList.Ref.Company AS Company,
-		   |	RetailSalesReceiptItemList.Ref.Branch AS Branch,
-		   |	RetailSalesReceiptItemList.ItemKey AS ItemKey,
-		   |	SUM(RetailSalesReceiptItemList.QuantityInBaseUnit) AS Quantity,
-		   |	SUM(ISNULL(RetailSalesReceiptSerialLotNumbers.Quantity, 0)) AS QuantityBySerialLtNumbers,
-		   |	RetailSalesReceiptItemList.Ref.Date AS Period,
-		   |	RetailSalesReceiptItemList.Ref AS RetailSalesReceipt,
-		   |	SUM(RetailSalesReceiptItemList.TotalAmount) AS Amount,
-		   |	SUM(RetailSalesReceiptItemList.NetAmount) AS NetAmount,
-		   |	SUM(RetailSalesReceiptItemList.OffersAmount) AS OffersAmount,
-		   |	RetailSalesReceiptItemList.Key AS RowKey,
-		   |	RetailSalesReceiptSerialLotNumbers.SerialLotNumber AS SerialLotNumber,
-		   |	RetailSalesReceiptItemList.Store
-		   |INTO tmpRetailSales
-		   |FROM
-		   |	Document.RetailSalesReceipt.ItemList AS RetailSalesReceiptItemList
-		   |		LEFT JOIN Document.RetailSalesReceipt.SerialLotNumbers AS RetailSalesReceiptSerialLotNumbers
-		   |		ON RetailSalesReceiptItemList.Key = RetailSalesReceiptSerialLotNumbers.Key
-		   |		AND RetailSalesReceiptItemList.Ref = RetailSalesReceiptSerialLotNumbers.Ref
-		   |		AND RetailSalesReceiptItemList.Ref = &Ref
-		   |		AND RetailSalesReceiptSerialLotNumbers.Ref = &Ref
-		   |WHERE
-		   |	RetailSalesReceiptItemList.Ref = &Ref
-		   |GROUP BY
-		   |	RetailSalesReceiptItemList.Ref.Company,
-		   |	RetailSalesReceiptItemList.Ref.Branch,
-		   |	RetailSalesReceiptItemList.ItemKey,
-		   |	RetailSalesReceiptItemList.Ref.Date,
-		   |	RetailSalesReceiptItemList.Ref,
-		   |	RetailSalesReceiptItemList.Key,
-		   |	RetailSalesReceiptSerialLotNumbers.SerialLotNumber,
-		   |	RetailSalesReceiptItemList.Store
-		   |;
-		   |
-		   |////////////////////////////////////////////////////////////////////////////////
-		   |SELECT
-		   |	tmpRetailSales.Company AS Company,
-		   |	tmpRetailSales.Branch AS Branch,
-		   |	tmpRetailSales.ItemKey AS ItemKey,
-		   |	CASE
-		   |		WHEN tmpRetailSales.QuantityBySerialLtNumbers = 0
-		   |			THEN tmpRetailSales.Quantity
-		   |		ELSE tmpRetailSales.QuantityBySerialLtNumbers
-		   |	END AS Quantity,
-		   |	tmpRetailSales.Period AS Period,
-		   |	tmpRetailSales.RetailSalesReceipt AS RetailSalesReceipt,
-		   |	tmpRetailSales.RowKey AS RowKey,
-		   |	tmpRetailSales.SerialLotNumber AS SerialLotNumber,
-		   |	CASE
-		   |		WHEN tmpRetailSales.QuantityBySerialLtNumbers <> 0
-		   |			THEN CASE
-		   |				WHEN tmpRetailSales.Quantity = 0
-		   |					THEN 0
-		   |				ELSE tmpRetailSales.Amount / tmpRetailSales.Quantity * tmpRetailSales.QuantityBySerialLtNumbers
-		   |			END
-		   |		ELSE tmpRetailSales.Amount
-		   |	END AS Amount,
-		   |	CASE
-		   |		WHEN tmpRetailSales.QuantityBySerialLtNumbers <> 0
-		   |			THEN CASE
-		   |				WHEN tmpRetailSales.Quantity = 0
-		   |					THEN 0
-		   |				ELSE tmpRetailSales.NetAmount / tmpRetailSales.Quantity * tmpRetailSales.QuantityBySerialLtNumbers
-		   |			END
-		   |		ELSE tmpRetailSales.NetAmount
-		   |	END AS NetAmount,
-		   |	CASE
-		   |		WHEN tmpRetailSales.QuantityBySerialLtNumbers <> 0
-		   |			THEN CASE
-		   |				WHEN tmpRetailSales.Quantity = 0
-		   |					THEN 0
-		   |				ELSE tmpRetailSales.OffersAmount / tmpRetailSales.Quantity * tmpRetailSales.QuantityBySerialLtNumbers
-		   |			END
-		   |		ELSE tmpRetailSales.OffersAmount
-		   |	END AS OffersAmount,
-		   |	tmpRetailSales.Store
-		   |INTO RetailSales
-		   |FROM
-		   |	tmpRetailSales AS tmpRetailSales";
+	|	RetailSalesReceiptItemList.Ref.Company AS Company,
+	|	RetailSalesReceiptItemList.Ref.Branch AS Branch,
+	|	RetailSalesReceiptItemList.ItemKey AS ItemKey,
+	|	SUM(RetailSalesReceiptItemList.QuantityInBaseUnit) AS Quantity,
+	|	SUM(ISNULL(RetailSalesReceiptSerialLotNumbers.Quantity, 0)) AS QuantityBySerialLtNumbers,
+	|	RetailSalesReceiptItemList.Ref.Date AS Period,
+	|	RetailSalesReceiptItemList.Ref AS RetailSalesReceipt,
+	|	SUM(RetailSalesReceiptItemList.TotalAmount) AS Amount,
+	|	SUM(RetailSalesReceiptItemList.NetAmount) AS NetAmount,
+	|	SUM(RetailSalesReceiptItemList.OffersAmount) AS OffersAmount,
+	|	RetailSalesReceiptItemList.Key AS RowKey,
+	|	RetailSalesReceiptSerialLotNumbers.SerialLotNumber AS SerialLotNumber,
+	|	RetailSalesReceiptItemList.Store,
+	|	RetailSalesReceiptItemList.SalesPerson
+	|INTO tmpRetailSales
+	|FROM
+	|	Document.RetailSalesReceipt.ItemList AS RetailSalesReceiptItemList
+	|		LEFT JOIN Document.RetailSalesReceipt.SerialLotNumbers AS RetailSalesReceiptSerialLotNumbers
+	|		ON RetailSalesReceiptItemList.Key = RetailSalesReceiptSerialLotNumbers.Key
+	|		AND RetailSalesReceiptItemList.Ref = RetailSalesReceiptSerialLotNumbers.Ref
+	|		AND RetailSalesReceiptItemList.Ref = &Ref
+	|		AND RetailSalesReceiptSerialLotNumbers.Ref = &Ref
+	|WHERE
+	|	RetailSalesReceiptItemList.Ref = &Ref
+	|GROUP BY
+	|	RetailSalesReceiptItemList.Ref.Company,
+	|	RetailSalesReceiptItemList.Ref.Branch,
+	|	RetailSalesReceiptItemList.ItemKey,
+	|	RetailSalesReceiptItemList.Ref.Date,
+	|	RetailSalesReceiptItemList.Ref,
+	|	RetailSalesReceiptItemList.Key,
+	|	RetailSalesReceiptSerialLotNumbers.SerialLotNumber,
+	|	RetailSalesReceiptItemList.Store,
+	|	RetailSalesReceiptItemList.SalesPerson
+	|;
+	|
+	|////////////////////////////////////////////////////////////////////////////////
+	|SELECT
+	|	tmpRetailSales.Company AS Company,
+	|	tmpRetailSales.Branch AS Branch,
+	|	tmpRetailSales.ItemKey AS ItemKey,
+	|	CASE
+	|		WHEN tmpRetailSales.QuantityBySerialLtNumbers = 0
+	|			THEN tmpRetailSales.Quantity
+	|		ELSE tmpRetailSales.QuantityBySerialLtNumbers
+	|	END AS Quantity,
+	|	tmpRetailSales.Period AS Period,
+	|	tmpRetailSales.RetailSalesReceipt AS RetailSalesReceipt,
+	|	tmpRetailSales.RowKey AS RowKey,
+	|	tmpRetailSales.SerialLotNumber AS SerialLotNumber,
+	|	CASE
+	|		WHEN tmpRetailSales.QuantityBySerialLtNumbers <> 0
+	|			THEN CASE
+	|				WHEN tmpRetailSales.Quantity = 0
+	|					THEN 0
+	|				ELSE tmpRetailSales.Amount / tmpRetailSales.Quantity * tmpRetailSales.QuantityBySerialLtNumbers
+	|			END
+	|		ELSE tmpRetailSales.Amount
+	|	END AS Amount,
+	|	CASE
+	|		WHEN tmpRetailSales.QuantityBySerialLtNumbers <> 0
+	|			THEN CASE
+	|				WHEN tmpRetailSales.Quantity = 0
+	|					THEN 0
+	|				ELSE tmpRetailSales.NetAmount / tmpRetailSales.Quantity * tmpRetailSales.QuantityBySerialLtNumbers
+	|			END
+	|		ELSE tmpRetailSales.NetAmount
+	|	END AS NetAmount,
+	|	CASE
+	|		WHEN tmpRetailSales.QuantityBySerialLtNumbers <> 0
+	|			THEN CASE
+	|				WHEN tmpRetailSales.Quantity = 0
+	|					THEN 0
+	|				ELSE tmpRetailSales.OffersAmount / tmpRetailSales.Quantity * tmpRetailSales.QuantityBySerialLtNumbers
+	|			END
+	|		ELSE tmpRetailSales.OffersAmount
+	|	END AS OffersAmount,
+	|	tmpRetailSales.Store
+	|INTO RetailSales
+	|FROM
+	|	tmpRetailSales AS tmpRetailSales";
 EndFunction
 
 Function OffersInfo()

--- a/IRP/src/Documents/RetailSalesReceipt/RetailSalesReceipt.mdo
+++ b/IRP/src/Documents/RetailSalesReceipt/RetailSalesReceipt.mdo
@@ -567,6 +567,26 @@
       <maxValue xsi:type="core:UndefinedValue"/>
       <dataHistory>Use</dataHistory>
     </attributes>
+    <attributes uuid="6920c0c3-907c-4af0-a745-84f34e095b72">
+      <name>SalesPerson</name>
+      <synonym>
+        <key>en</key>
+        <value>Sales person</value>
+      </synonym>
+      <type>
+        <types>CatalogRef.Partners</types>
+      </type>
+      <minValue xsi:type="core:UndefinedValue"/>
+      <maxValue xsi:type="core:UndefinedValue"/>
+      <choiceParameters>
+        <name>Filter.Employee</name>
+        <value xsi:type="core:BooleanValue">
+          <value>true</value>
+        </value>
+      </choiceParameters>
+      <dataHistory>Use</dataHistory>
+      <fullTextSearch>Use</fullTextSearch>
+    </attributes>
   </tabularSections>
   <tabularSections uuid="0d32dd7b-16e6-4c0b-a360-865e3d47dc78">
     <producedTypes>

--- a/IRP/src/InformationRegisters/RetailWorkers/RetailWorkers.mdo
+++ b/IRP/src/InformationRegisters/RetailWorkers/RetailWorkers.mdo
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdclass:InformationRegister xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:core="http://g5.1c.ru/v8/dt/mcore" xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="47e275f7-e49e-417d-be56-af13a5678697">
+  <producedTypes>
+    <selectionType typeId="56bc7f8a-3449-4076-ab66-b1653e04c533" valueTypeId="c5529284-2fed-4f3d-a4bc-fb8afb046ea6"/>
+    <listType typeId="9ff46a28-4ee2-4f7b-9282-8cad32978c37" valueTypeId="41995470-db0f-4ded-895b-5e6be4675f0d"/>
+    <managerType typeId="c9e1aabc-4bec-48c1-9076-29fa96721f99" valueTypeId="6658284f-7876-41d8-ab07-426e3133e77f"/>
+    <recordSetType typeId="caf0f365-863e-45f3-96aa-8dbffb82d235" valueTypeId="0c79cd71-c2c2-4f69-81cd-5fcb87a90b38"/>
+    <recordKeyType typeId="b7624d95-c43b-4e29-b5ec-fc42e0415a78" valueTypeId="21d2da8d-0a68-4009-be90-f0bf55ba1952"/>
+    <recordType typeId="af1fc798-6138-4d0c-b73b-a25d4a5ec391" valueTypeId="0b391cb1-9526-49a9-9c6c-803bf31a8d68"/>
+    <recordManagerType typeId="77aa1028-c66a-430a-ade5-a331c7ef3d50" valueTypeId="242cc778-6d1d-4f83-ba2e-4a6029904a39"/>
+  </producedTypes>
+  <name>RetailWorkers</name>
+  <synonym>
+    <key>en</key>
+    <value>Retail workers</value>
+  </synonym>
+  <useStandardCommands>true</useStandardCommands>
+  <editType>InDialog</editType>
+  <dataLockControlMode>Managed</dataLockControlMode>
+  <recordPresentation>
+    <key>en</key>
+    <value>Retail workers</value>
+  </recordPresentation>
+  <dimensions uuid="321bdc86-9ea1-43df-a7c6-dee15456fa0e">
+    <name>Store</name>
+    <synonym>
+      <key>en</key>
+      <value>Store</value>
+    </synonym>
+    <type>
+      <types>CatalogRef.Stores</types>
+    </type>
+    <createOnInput>DontUse</createOnInput>
+    <denyIncompleteValues>true</denyIncompleteValues>
+    <fillFromFillingValue>true</fillFromFillingValue>
+    <choiceHistoryOnInput>DontUse</choiceHistoryOnInput>
+    <master>true</master>
+    <mainFilter>true</mainFilter>
+  </dimensions>
+  <dimensions uuid="c693dde5-ac16-4825-979f-eae5f739a44b">
+    <name>Worker</name>
+    <synonym>
+      <key>en</key>
+      <value>Worker</value>
+    </synonym>
+    <type>
+      <types>CatalogRef.Partners</types>
+    </type>
+    <minValue xsi:type="core:UndefinedValue"/>
+    <maxValue xsi:type="core:UndefinedValue"/>
+    <choiceParameters>
+      <name>Filter.Employee</name>
+      <value xsi:type="core:BooleanValue">
+        <value>true</value>
+      </value>
+    </choiceParameters>
+    <denyIncompleteValues>true</denyIncompleteValues>
+    <fullTextSearch>Use</fullTextSearch>
+    <dataHistory>Use</dataHistory>
+    <fillFromFillingValue>true</fillFromFillingValue>
+    <fillValue xsi:type="core:UndefinedValue"/>
+    <master>true</master>
+    <mainFilter>true</mainFilter>
+  </dimensions>
+</mdclass:InformationRegister>

--- a/IRP/src/Subsystems/Retail/Retail.mdo
+++ b/IRP/src/Subsystems/Retail/Retail.mdo
@@ -19,4 +19,5 @@
   <content>Catalog.CashStatementStatuses</content>
   <content>AccumulationRegister.R3050T_RetailCash</content>
   <content>AccumulationRegister.R2050T_RetailSales</content>
+  <content>InformationRegister.RetailWorkers</content>
 </mdclass:Subsystem>


### PR DESCRIPTION
Добавил реквизиты в таблицы документов розничной продажи и возврата.
Добавил движения по регистру 2050

Добавил регистр сведений для указания сотрудников:
![image](https://user-images.githubusercontent.com/11927866/147886136-86893d6f-5839-4967-bd55-5d510b897c07.png)

Кейсы:
1. Если нет ни одного сотрудника в регистре, то ничего не изменилось, относительно того, что ыбло раньше.
2. Если есть ТОЛЬКО ОДИН сотрудник, то тогда он по умолчанию будет всегда рассчитываться и подставляться для этого склада.
3. Если более чем один, тогда выйдет поле выбора, где надо указать нужного сотрудника. И он же будет подставляться при каждой следующей продаже. 

Если сотруник уже выбран, то по окончанию продажи - он очищается.
Если я пробил Товар1, потом нажал на кнопку изменить сотрудника (нажатие сработает толкьо если больше 1 сотрудника есть), и выбрал нового сотрудника, то тогда все НОВЫЕ строки будут диться под него.
