### PR TITLE
#1530

### DIFF
--- a/IRP/src/CommonModules/JorDocumentsClient/Module.bsl
+++ b/IRP/src/CommonModules/JorDocumentsClient/Module.bsl
@@ -42,6 +42,24 @@ Procedure BasisDocumentStartChoice(Object, Form, Item, CurrentData, Parameters) 
 		CreditNoteTableName);
 	FormParameters = New Structure("CustomFilter", FilterStructure);
 
+	EnteredItems = New Array;
+	For Each PaymentListItem in Object.PaymentList Do
+		If Not PaymentListItem = CurrentData Then
+			StructureEnteredItem = JorDocumentsClientServer.GetStructureEnteredItem();
+			StructureEnteredItem.Ref = PaymentListItem.BasisDocument;
+			StructureEnteredItem.Company = Object.Company;
+			StructureEnteredItem.Partner = PaymentListItem.Partner;
+			StructureEnteredItem.Agreement = PaymentListItem.Agreement;
+			StructureEnteredItem.Currency = Object.Currency;
+			StructureEnteredItem.Amount = PaymentListItem.TotalAmount;
+			If FilterStructure.QueryParameters.Property("LegalName") Then
+				StructureEnteredItem.LegalName = FilterStructure.QueryParameters.LegalName;
+			EndIf;
+			EnteredItems.Add(StructureEnteredItem);
+		EndIf;
+	EndDo;
+	FormParameters.Insert("EnteredItems", EnteredItems);
+
 	OpenForm("DocumentJournal." + Parameters.TableName + ".Form.ChoiceForm", FormParameters, Item, Form.UUID, , Form.URL,
 		Parameters.Notify, FormWindowOpeningMode.LockOwnerWindow);
 EndProcedure

--- a/IRP/src/CommonModules/JorDocumentsClient/Module.bsl
+++ b/IRP/src/CommonModules/JorDocumentsClient/Module.bsl
@@ -59,6 +59,8 @@ Procedure BasisDocumentStartChoice(Object, Form, Item, CurrentData, Parameters) 
 		EndIf;
 	EndDo;
 	FormParameters.Insert("EnteredItems", EnteredItems);
+	FormParameters.Insert("DocumentRef",  Parameters.Ref);
+	FormParameters.Insert("DocumentDate", Object.Date);
 
 	OpenForm("DocumentJournal." + Parameters.TableName + ".Form.ChoiceForm", FormParameters, Item, Form.UUID, , Form.URL,
 		Parameters.Notify, FormWindowOpeningMode.LockOwnerWindow);
@@ -69,6 +71,33 @@ Function CreateFilterByParameters(Ref, Parameters, TableName,
 			OpeningEntryTableName2, 
 			DebitNoteTableName, 
 			CreditNoteTableName)
+
+	QueryParameters = New Structure();
+	QueryParameters.Insert("Ref", Ref);
+	QueryParameters.Insert("IsReturnTransactionType", Parameters.IsReturnTransactionType);
+	QueryParameters.Insert("ShowAll", False);
+	
+	QueryText_Doc = GetDocQueryText(QueryParameters, Parameters, TableName, 
+			OpeningEntryTableName1, 
+			OpeningEntryTableName2, 
+			DebitNoteTableName, 
+			CreditNoteTableName);
+	QueryText_DocWithBalance = GetDocWithBalanceQueryText();
+	QueryText_AllDoc = GetAllDocQueryText();
+	QueryText = QueryText_Doc + "; " + QueryText_DocWithBalance + "; " + QueryText_AllDoc;  
+
+	FilterStructure = New Structure();
+	FilterStructure.Insert("QueryText", QueryText);
+	FilterStructure.Insert("QueryParameters", QueryParameters);
+	Return FilterStructure;
+EndFunction
+
+Function GetDocQueryText(QueryParameters, Parameters, TableName, 
+			OpeningEntryTableName1, 
+			OpeningEntryTableName2, 
+			DebitNoteTableName, 
+			CreditNoteTableName)
+
 	QueryText_TableName = 
 	"SELECT ALLOWED
 	|	Obj.Ref,
@@ -169,16 +198,10 @@ Function CreateFilterByParameters(Ref, Parameters, TableName,
 		|	CreditNote.Ref";
 	EndIf;
 
-	QueryParameters = New Structure();
-	QueryParameters.Insert("Ref", Ref);
-	QueryParameters.Insert("IsReturnTransactionType", Parameters.IsReturnTransactionType);
-
 	ArrayOfConditions = New Array();
 	ArrayOfConditionsOpeningEntry = New Array();
 	ArrayOfConditionsDebitNote = New Array();
 	ArrayOfConditionsCreditNote = New Array();
-
-	QueryParameters.Insert("ShowAll", False);
 
 	If Parameters.Property("Type") Then
 		QueryParameters.Insert("Type", Parameters.Type);
@@ -275,11 +298,18 @@ Function CreateFilterByParameters(Ref, Parameters, TableName,
 	If CreditNoteTableName <> Undefined Then
 		QueryText_CreditNote = StrTemplate(QueryText_CreditNote, CreditNoteTableName, ConditionsCreditNoteText);
 	EndIf;
+	
+	Return QueryText_TableName + 
+			QueryText_OpeningEntryTableName1 + 
+			QueryText_OpeningEntryTableName2 + 
+			QueryText_DebitNote	+ 
+			QueryText_CreditNote;
+			
+EndFunction
 
-	QueryText = QueryText_TableName + QueryText_OpeningEntryTableName1 + QueryText_OpeningEntryTableName2 + QueryText_DebitNote
-	+ QueryText_CreditNote +
-	"; 
-	|SELECT ALLOWED
+Function GetDocWithBalanceQueryText()
+	QueryText_DocWithBalance = 
+	"SELECT ALLOWED
 	|	CustomersTransactions.Basis AS Ref,
 	|	CustomersTransactions.Company AS Company,
 	|	CustomersTransactions.Partner AS Partner,
@@ -406,10 +436,131 @@ Function CreateFilterByParameters(Ref, Parameters, TableName,
 	|		FROM
 	|			Doc AS Doc)) AS SalesOrdersToBePaid
 	|WHERE
-	|	SalesOrdersToBePaid.AmountBalance > 0
-	|;
+	|	SalesOrdersToBePaid.AmountBalance > 0";
+	
+	QueryText_Postings =
+	"
+	|UNION ALL
 	|
-	|////////////////////////////////////////////////////////////////////////////////
+	|SELECT
+	|	Postings.Ref,
+	|	Postings.Company,
+	|	Postings.Partner,
+	|	Postings.LegalName,
+	|	Postings.Agreement,
+	|	Postings.Currency,
+	|	SUM(Postings.Amount) AS Amount
+	|FROM
+	|	(SELECT
+	|		CustomersTransactions.Basis AS Ref,
+	|		CustomersTransactions.Company AS Company,
+	|		CustomersTransactions.Partner AS Partner,
+	|		CustomersTransactions.LegalName AS LegalName,
+	|		CustomersTransactions.Agreement AS Agreement,
+	|		CustomersTransactions.Currency AS Currency,
+	|		CASE
+	|			WHEN CustomersTransactions.RecordType = VALUE(AccumulationRecordType.Expense)
+	|				THEN 1
+	|			ELSE -1
+	|		END * CASE
+	|			WHEN &IsReturnTransactionType
+	|				THEN CASE
+	|					WHEN CustomersTransactions.Basis REFS Document.SalesReturn
+	|						THEN -CustomersTransactions.Amount
+	|					ELSE 0
+	|				END
+	|			ELSE CustomersTransactions.Amount
+	|		END AS Amount
+	|	FROM
+	|		AccumulationRegister.R2021B_CustomersTransactions AS CustomersTransactions
+	|	WHERE
+	|		CustomersTransactions.Recorder = &Ref
+	|		AND CustomersTransactions.Period < &Period
+	|		AND
+	|			CustomersTransactions.CurrencyMovementType = VALUE(ChartOfCharacteristicTypes.CurrencyMovementType.SettlementCurrency)
+	|
+	|	UNION ALL
+	|
+	|	SELECT
+	|		VendorsTransactions.Basis,
+	|		VendorsTransactions.Company,
+	|		VendorsTransactions.Partner,
+	|		VendorsTransactions.LegalName,
+	|		VendorsTransactions.Agreement,
+	|		VendorsTransactions.Currency,
+	|		CASE
+	|			WHEN VendorsTransactions.RecordType = VALUE(AccumulationRecordType.Expense)
+	|				THEN 1
+	|			ELSE -1
+	|		END * CASE
+	|			WHEN &IsReturnTransactionType
+	|				THEN CASE
+	|					WHEN VendorsTransactions.Basis REFS Document.PurchaseReturn
+	|						THEN -VendorsTransactions.Amount
+	|					ELSE 0
+	|				END
+	|			ELSE VendorsTransactions.Amount
+	|		END
+	|	FROM
+	|		AccumulationRegister.R1021B_VendorsTransactions AS VendorsTransactions
+	|	WHERE
+	|		VendorsTransactions.Recorder = &Ref
+	|		AND VendorsTransactions.Period < &Period
+	|		AND
+	|			VendorsTransactions.CurrencyMovementType = VALUE(ChartOfCharacteristicTypes.CurrencyMovementType.SettlementCurrency)
+	|
+	|	UNION ALL
+	|
+	|	SELECT
+	|		PurchaseOrdersToBePaid.Order,
+	|		PurchaseOrdersToBePaid.Company,
+	|		PurchaseOrdersToBePaid.Partner,
+	|		PurchaseOrdersToBePaid.LegalName,
+	|		PurchaseOrdersToBePaid.Order.Agreement,
+	|		PurchaseOrdersToBePaid.Currency,
+	|		CASE
+	|			WHEN PurchaseOrdersToBePaid.RecordType = VALUE(AccumulationRecordType.Expense)
+	|				THEN 1
+	|			ELSE -1
+	|		END * PurchaseOrdersToBePaid.Amount
+	|	FROM
+	|		AccumulationRegister.R3025B_PurchaseOrdersToBePaid AS PurchaseOrdersToBePaid
+	|	WHERE
+	|		PurchaseOrdersToBePaid.Recorder = &Ref
+	|		AND PurchaseOrdersToBePaid.Period < &Period
+	|
+	|	UNION ALL
+	|
+	|	SELECT
+	|		SalesOrdersToBePaid.Order,
+	|		SalesOrdersToBePaid.Company,
+	|		SalesOrdersToBePaid.Partner,
+	|		SalesOrdersToBePaid.LegalName,
+	|		SalesOrdersToBePaid.Order.Agreement,
+	|		SalesOrdersToBePaid.Currency,
+	|		CASE
+	|			WHEN SalesOrdersToBePaid.RecordType = VALUE(AccumulationRecordType.Expense)
+	|				THEN 1
+	|			ELSE -1
+	|		END * SalesOrdersToBePaid.Amount
+	|	FROM
+	|		AccumulationRegister.R3024B_SalesOrdersToBePaid AS SalesOrdersToBePaid
+	|	WHERE
+	|		SalesOrdersToBePaid.Recorder = &Ref
+	|		AND SalesOrdersToBePaid.Period < &Period) AS Postings
+	|GROUP BY
+	|	Postings.Ref,
+	|	Postings.Company,
+	|	Postings.Partner,
+	|	Postings.LegalName,
+	|	Postings.Agreement,
+	|	Postings.Currency";
+	Return QueryText_DocWithBalance + QueryText_Postings;
+EndFunction
+
+Function GetAllDocQueryText()
+	Return
+	"////////////////////////////////////////////////////////////////////////////////
 	|SELECT
 	|	DocWithBalance.Ref,
 	|	DocWithBalance.Company,
@@ -456,10 +607,4 @@ Function CreateFilterByParameters(Ref, Parameters, TableName,
 	|	AllDoc.LegalName,
 	|	AllDoc.Agreement,
 	|	AllDoc.Currency";
-
-	FilterStructure = New Structure();
-	FilterStructure.Insert("QueryText", QueryText);
-	FilterStructure.Insert("QueryParameters", QueryParameters);
-
-	Return FilterStructure;
 EndFunction

--- a/IRP/src/CommonModules/JorDocumentsClientServer/JorDocumentsClientServer.mdo
+++ b/IRP/src/CommonModules/JorDocumentsClientServer/JorDocumentsClientServer.mdo
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdclass:CommonModule xmlns:mdclass="http://g5.1c.ru/v8/dt/metadata/mdclass" uuid="1d8b0f76-8c9d-45ff-8c86-f1cbe9619733">
+  <name>JorDocumentsClientServer</name>
+  <synonym>
+    <key>en</key>
+    <value>Jor documents client server</value>
+  </synonym>
+  <clientManagedApplication>true</clientManagedApplication>
+  <server>true</server>
+  <externalConnection>true</externalConnection>
+  <clientOrdinaryApplication>true</clientOrdinaryApplication>
+  <serverCall>true</serverCall>
+</mdclass:CommonModule>

--- a/IRP/src/CommonModules/JorDocumentsClientServer/Module.bsl
+++ b/IRP/src/CommonModules/JorDocumentsClientServer/Module.bsl
@@ -21,3 +21,20 @@ Function GetStructureEnteredItem() Export
 	Resultat.Insert("Amount", 0);
 	Return Resultat;
 EndFunction
+
+// Set period in dynamic list.
+// 
+// Parameters:
+//  List - DynamicList - list to set the date
+//  ByDocumentDate - Boolean - By document date (otherwise by current date)
+Procedure SetPeriodInDynamicList(List, ByDocumentDate) Export
+	NewPeriod = EndOfDay(CurrentDate());
+	If ByDocumentDate Then
+		AdditionalParameters = Undefined; // Structure
+		If List.SettingsComposer.Settings.AdditionalProperties.Property("AdditionalParameters", AdditionalParameters) Then
+			NewPeriod = CommonFunctionsClientServer.GetSliceLastDateByRefAndDate(
+				AdditionalParameters.Ref, AdditionalParameters.DocumentDate);
+		EndIf;
+	EndIf;
+	List.Parameters.SetParameterValue("Period", NewPeriod);
+EndProcedure

--- a/IRP/src/CommonModules/JorDocumentsClientServer/Module.bsl
+++ b/IRP/src/CommonModules/JorDocumentsClientServer/Module.bsl
@@ -1,0 +1,23 @@
+
+// Get structure of entered item.
+// 
+// Returns:
+//  Structure - Get structure entered item:
+// * Ref - Undefined - Basis document
+// * Company - Undefined - Company
+// * Partner - Undefined - Partner
+// * LegalName - Undefined - LegalName
+// * Agreement - Undefined - Agreement
+// * Currency - Undefined - Currency
+// * Amount - Number - Amount
+Function GetStructureEnteredItem() Export
+	Resultat = New Structure;
+	Resultat.Insert("Ref", Undefined);
+	Resultat.Insert("Company", Undefined);
+	Resultat.Insert("Partner", Undefined);
+	Resultat.Insert("LegalName", Undefined);
+	Resultat.Insert("Agreement", Undefined);
+	Resultat.Insert("Currency", Undefined);
+	Resultat.Insert("Amount", 0);
+	Return Resultat;
+EndFunction

--- a/IRP/src/CommonModules/JorDocumentsServer/Module.bsl
+++ b/IRP/src/CommonModules/JorDocumentsServer/Module.bsl
@@ -12,11 +12,75 @@ Procedure OnCreateAtServer(Cancel, StandardProcessing, Form, Parameters) Export
 		Period = EndOfDay(CurrentSessionDate());
 		If ValueIsFilled(Ref) Then
 			If Ref.Posted Then
-				Period = New Boundary(Ref.PointInTime(), BoundaryType.Including);
+				Period = New Boundary(Ref.PointInTime(), BoundaryType.Excluding);
 			Else
 				Period = EndOfDay(Ref.Date);
 			EndIf;
 		EndIf;
 		Form.List.Parameters.SetParameterValue("Period", Period);
 	EndIf;
+	
+	AdditionalProperties = Form.List.SettingsComposer.Settings.AdditionalProperties;
+	AdditionalParameters = Undefined;
+	If Not AdditionalProperties.Property("AdditionalParameters", AdditionalParameters) Then
+		AdditionalParameters = New Structure;
+	EndIf;
+	
+	EnteredItems = Undefined;
+	If Not Parameters.Property("EnteredItems", EnteredItems) Then
+		EnteredItems = New Array;
+	EndIf;
+	If Ref.Posted Then
+		
+	EndIf;
+	
+	AdditionalParameters.Insert("EnteredItems", EnteredItems);
+	AdditionalProperties.Insert("AdditionalParameters", AdditionalParameters);
+	
 EndProcedure
+
+Procedure ListOnGetDataAtServer(ItemName, Settings, Rows) Export
+	FilterKey = "Ref, Company, Partner, LegalName, Agreement, Currency";
+	
+	EnteredItems = GetTableEnteredItems();
+	If Settings.AdditionalProperties.Property("AdditionalParameters") 
+			And Settings.AdditionalProperties.AdditionalParameters.Property("EnteredItems") Then
+		For Each EnteredItem in Settings.AdditionalProperties.AdditionalParameters.EnteredItems Do
+			FillPropertyValues(EnteredItems.Add(), EnteredItem);
+		EndDo;
+	EndIf;
+	EnteredItems.GroupBy(FilterKey, "Amount");
+	
+	Filter = New Structure(FilterKey);
+	For Each RowItem In Rows Do
+		FillPropertyValues(Filter, RowItem.Value.Data);
+		FindedEnteredItems = EnteredItems.FindRows(Filter);
+		For Each EnteredItem In FindedEnteredItems Do 
+			NewAmount = Max(RowItem.Value.Data.DocumentAmount - EnteredItem.Amount, 0);
+			RowItem.Value.Data.DocumentAmount = NewAmount; 
+		EndDo;
+	EndDo;
+EndProcedure
+
+// Get table of entered items.
+// 
+// Returns:
+//  ValueTable - Table of entered items:
+// * Ref - DocumentRef - Basis document
+// * Company - CatalogRef.Companies - Company
+// * Partner - CatalogRef.Partners - Partner
+// * LegalName - CatalogRef.Companies - LegalName
+// * Agreement - CatalogRef.Agreements - Agreement
+// * Currency - CatalogRef.Currencies - Currency
+// * Amount - Number - Amount
+Function GetTableEnteredItems() Export
+	Resultat = New ValueTable();
+	Resultat.Columns.Add("Ref", New TypeDescription("DocumentRef"));
+	Resultat.Columns.Add("Company", New TypeDescription("CatalogRef.Companies"));
+	Resultat.Columns.Add("Partner", New TypeDescription("CatalogRef.Partners"));
+	Resultat.Columns.Add("LegalName", New TypeDescription("CatalogRef.Companies"));
+	Resultat.Columns.Add("Agreement", New TypeDescription("CatalogRef.Agreements"));
+	Resultat.Columns.Add("Currency", New TypeDescription("CatalogRef.Currencies"));
+	Resultat.Columns.Add("Amount", New TypeDescription("Number"));
+	Return Resultat;
+EndFunction

--- a/IRP/src/CommonModules/JorDocumentsServer/Module.bsl
+++ b/IRP/src/CommonModules/JorDocumentsServer/Module.bsl
@@ -12,7 +12,7 @@ Procedure OnCreateAtServer(Cancel, StandardProcessing, Form, Parameters) Export
 		Period = EndOfDay(CurrentSessionDate());
 		If ValueIsFilled(Ref) Then
 			If Ref.Posted Then
-				Period = New Boundary(Ref.PointInTime(), BoundaryType.Excluding);
+				Period = New Boundary(Ref.PointInTime(), BoundaryType.Including);
 			Else
 				Period = EndOfDay(Ref.Date);
 			EndIf;

--- a/IRP/src/CommonModules/JorDocumentsServer/Module.bsl
+++ b/IRP/src/CommonModules/JorDocumentsServer/Module.bsl
@@ -75,7 +75,7 @@ EndProcedure
 // * Amount - Number - Amount
 Function GetTableEnteredItems() Export
 	Resultat = New ValueTable();
-	Resultat.Columns.Add("Ref", New TypeDescription("DocumentRef"));
+	Resultat.Columns.Add("Ref", Documents.AllRefsType());
 	Resultat.Columns.Add("Company", New TypeDescription("CatalogRef.Companies"));
 	Resultat.Columns.Add("Partner", New TypeDescription("CatalogRef.Partners"));
 	Resultat.Columns.Add("LegalName", New TypeDescription("CatalogRef.Companies"));

--- a/IRP/src/Configuration/Configuration.mdo
+++ b/IRP/src/Configuration/Configuration.mdo
@@ -373,6 +373,7 @@
   <commonModules>CommonModule.IntegrationServerPrivileged</commonModules>
   <commonModules>CommonModule.IntegrationServerReuse</commonModules>
   <commonModules>CommonModule.JorDocumentsClient</commonModules>
+  <commonModules>CommonModule.JorDocumentsClientServer</commonModules>
   <commonModules>CommonModule.JorDocumentsServer</commonModules>
   <commonModules>CommonModule.LandedCostServer</commonModules>
   <commonModules>CommonModule.Localization</commonModules>

--- a/IRP/src/DocumentJournals/DocumentsForIncomingPayment/Forms/ChoiceForm/Form.form
+++ b/IRP/src/DocumentJournals/DocumentsForIncomingPayment/Forms/ChoiceForm/Form.form
@@ -38,6 +38,175 @@
       <currentRowUse>Auto</currentRowUse>
     </extInfo>
   </items>
+  <items xsi:type="form:FormGroup">
+    <name>GroupHeader</name>
+    <id>58</id>
+    <items xsi:type="form:Button">
+      <name>FormCommandSelect</name>
+      <id>25</id>
+      <visible>true</visible>
+      <enabled>true</enabled>
+      <userVisible>
+        <common>true</common>
+      </userVisible>
+      <extendedTooltip>
+        <name>FormCommandSelectExtendedTooltip</name>
+        <id>26</id>
+        <visible>true</visible>
+        <enabled>true</enabled>
+        <userVisible>
+          <common>true</common>
+        </userVisible>
+        <type>Label</type>
+        <autoMaxWidth>true</autoMaxWidth>
+        <autoMaxHeight>true</autoMaxHeight>
+        <extInfo xsi:type="form:LabelDecorationExtInfo">
+          <horizontalAlign>Left</horizontalAlign>
+        </extInfo>
+      </extendedTooltip>
+      <type>UsualButton</type>
+      <commandName>Form.Command.CommandSelect</commandName>
+      <representation>Auto</representation>
+      <defaultButton>true</defaultButton>
+      <autoMaxWidth>true</autoMaxWidth>
+      <autoMaxHeight>true</autoMaxHeight>
+      <placementArea>UserCmds</placementArea>
+      <representationInContextMenu>Auto</representationInContextMenu>
+    </items>
+    <items xsi:type="form:Decoration">
+      <name>HeaderSpace</name>
+      <id>60</id>
+      <title>
+        <key>en</key>
+        <value> </value>
+      </title>
+      <visible>true</visible>
+      <enabled>true</enabled>
+      <userVisible>
+        <common>true</common>
+      </userVisible>
+      <extendedTooltip>
+        <name>HeaderSpaceExtendedTooltip</name>
+        <id>62</id>
+        <visible>true</visible>
+        <enabled>true</enabled>
+        <userVisible>
+          <common>true</common>
+        </userVisible>
+        <type>Label</type>
+        <autoMaxWidth>true</autoMaxWidth>
+        <autoMaxHeight>true</autoMaxHeight>
+        <extInfo xsi:type="form:LabelDecorationExtInfo">
+          <horizontalAlign>Left</horizontalAlign>
+        </extInfo>
+      </extendedTooltip>
+      <contextMenu>
+        <name>HeaderSpaceContextMenu</name>
+        <id>61</id>
+        <visible>true</visible>
+        <enabled>true</enabled>
+        <userVisible>
+          <common>true</common>
+        </userVisible>
+        <autoFill>true</autoFill>
+      </contextMenu>
+      <type>Label</type>
+      <autoMaxHeight>true</autoMaxHeight>
+      <horizontalStretch>true</horizontalStretch>
+      <extInfo xsi:type="form:LabelDecorationExtInfo">
+        <horizontalAlign>Left</horizontalAlign>
+      </extInfo>
+    </items>
+    <items xsi:type="form:FormField">
+      <name>AmountByDocumentDate</name>
+      <id>55</id>
+      <title>
+        <key>en</key>
+        <value>Status</value>
+      </title>
+      <visible>true</visible>
+      <enabled>true</enabled>
+      <userVisible>
+        <common>true</common>
+      </userVisible>
+      <dataPath xsi:type="form:DataPath">
+        <segments>AmountByDocumentDate</segments>
+      </dataPath>
+      <handlers>
+        <event>OnChange</event>
+        <name>AmountByDocumentDateOnChange</name>
+      </handlers>
+      <extendedTooltip>
+        <name>AmountByDocumentDateExtendedTooltip</name>
+        <id>57</id>
+        <visible>true</visible>
+        <enabled>true</enabled>
+        <userVisible>
+          <common>true</common>
+        </userVisible>
+        <type>Label</type>
+        <autoMaxWidth>true</autoMaxWidth>
+        <autoMaxHeight>true</autoMaxHeight>
+        <extInfo xsi:type="form:LabelDecorationExtInfo">
+          <horizontalAlign>Left</horizontalAlign>
+        </extInfo>
+      </extendedTooltip>
+      <contextMenu>
+        <name>AmountByDocumentDateContextMenu</name>
+        <id>56</id>
+        <visible>true</visible>
+        <enabled>true</enabled>
+        <userVisible>
+          <common>true</common>
+        </userVisible>
+        <autoFill>true</autoFill>
+      </contextMenu>
+      <type>CheckBoxField</type>
+      <editMode>Enter</editMode>
+      <showInHeader>true</showInHeader>
+      <headerHorizontalAlign>Left</headerHorizontalAlign>
+      <showInFooter>true</showInFooter>
+      <extInfo xsi:type="form:CheckBoxFieldExtInfo">
+        <checkBoxType>Tumbler</checkBoxType>
+        <editFormat>
+          <key>en</key>
+          <value>BF='Current time'; BT='By document date'</value>
+        </editFormat>
+      </extInfo>
+    </items>
+    <visible>true</visible>
+    <enabled>true</enabled>
+    <userVisible>
+      <common>true</common>
+    </userVisible>
+    <title>
+      <key>en</key>
+      <value>Group of header</value>
+    </title>
+    <extendedTooltip>
+      <name>GroupHeaderExtendedTooltip</name>
+      <id>59</id>
+      <visible>true</visible>
+      <enabled>true</enabled>
+      <userVisible>
+        <common>true</common>
+      </userVisible>
+      <type>Label</type>
+      <autoMaxWidth>true</autoMaxWidth>
+      <autoMaxHeight>true</autoMaxHeight>
+      <extInfo xsi:type="form:LabelDecorationExtInfo">
+        <horizontalAlign>Left</horizontalAlign>
+      </extInfo>
+    </extendedTooltip>
+    <type>UsualGroup</type>
+    <extInfo xsi:type="form:UsualGroupExtInfo">
+      <group>AlwaysHorizontal</group>
+      <showLeftMargin>true</showLeftMargin>
+      <united>true</united>
+      <throughAlign>Auto</throughAlign>
+      <currentRowUse>Auto</currentRowUse>
+    </extInfo>
+  </items>
   <items xsi:type="form:Table">
     <name>List</name>
     <id>3</id>
@@ -610,37 +779,6 @@
   <autoCommandBar>
     <name>FormCommandBar</name>
     <id>-1</id>
-    <items xsi:type="form:Button">
-      <name>FormCommandSelect</name>
-      <id>25</id>
-      <visible>true</visible>
-      <enabled>true</enabled>
-      <userVisible>
-        <common>true</common>
-      </userVisible>
-      <extendedTooltip>
-        <name>FormCommandSelectExtendedTooltip</name>
-        <id>26</id>
-        <visible>true</visible>
-        <enabled>true</enabled>
-        <userVisible>
-          <common>true</common>
-        </userVisible>
-        <type>Label</type>
-        <autoMaxWidth>true</autoMaxWidth>
-        <autoMaxHeight>true</autoMaxHeight>
-        <extInfo xsi:type="form:LabelDecorationExtInfo">
-          <horizontalAlign>Left</horizontalAlign>
-        </extInfo>
-      </extendedTooltip>
-      <commandName>Form.Command.CommandSelect</commandName>
-      <representation>Auto</representation>
-      <defaultButton>true</defaultButton>
-      <autoMaxWidth>true</autoMaxWidth>
-      <autoMaxHeight>true</autoMaxHeight>
-      <placementArea>UserCmds</placementArea>
-      <representationInContextMenu>Auto</representationInContextMenu>
-    </items>
     <visible>true</visible>
     <enabled>true</enabled>
     <userVisible>
@@ -689,6 +827,23 @@ FROM
       <autoSaveUserSettings>true</autoSaveUserSettings>
       <getInvisibleFieldPresentations>true</getInvisibleFieldPresentations>
     </extInfo>
+  </attributes>
+  <attributes>
+    <name>AmountByDocumentDate</name>
+    <title>
+      <key>en</key>
+      <value>Amount by document date</value>
+    </title>
+    <id>2</id>
+    <valueType>
+      <types>Boolean</types>
+    </valueType>
+    <view>
+      <common>true</common>
+    </view>
+    <edit>
+      <common>true</common>
+    </edit>
   </attributes>
   <formCommands>
     <name>CommandSelect</name>

--- a/IRP/src/DocumentJournals/DocumentsForIncomingPayment/Forms/ChoiceForm/Form.form
+++ b/IRP/src/DocumentJournals/DocumentsForIncomingPayment/Forms/ChoiceForm/Form.form
@@ -593,6 +593,10 @@
       <segments>List.DefaultPicture</segments>
     </rowPictureDataPath>
     <extInfo xsi:type="form:DynamicListTableExtInfo">
+      <handlers>
+        <event>OnGetDataAtServer</event>
+        <name>ListOnGetDataAtServer</name>
+      </handlers>
       <autoRefreshPeriod>60</autoRefreshPeriod>
       <period>
         <startDate>0001-01-01T00:00:00</startDate>
@@ -635,7 +639,6 @@
       <autoMaxWidth>true</autoMaxWidth>
       <autoMaxHeight>true</autoMaxHeight>
       <placementArea>UserCmds</placementArea>
-      <toolTipRepresentation>Auto</toolTipRepresentation>
       <representationInContextMenu>Auto</representationInContextMenu>
     </items>
     <visible>true</visible>

--- a/IRP/src/DocumentJournals/DocumentsForIncomingPayment/Forms/ChoiceForm/Module.bsl
+++ b/IRP/src/DocumentJournals/DocumentsForIncomingPayment/Forms/ChoiceForm/Module.bsl
@@ -33,3 +33,8 @@ EndFunction
 Procedure ListOnGetDataAtServer(ItemName, Settings, Rows)
 	JorDocumentsServer.ListOnGetDataAtServer(ItemName, Settings, Rows);
 EndProcedure
+
+&AtClient
+Procedure AmountByDocumentDateOnChange(Item)
+	JorDocumentsClientServer.SetPeriodInDynamicList(List, AmountByDocumentDate);
+EndProcedure

--- a/IRP/src/DocumentJournals/DocumentsForIncomingPayment/Forms/ChoiceForm/Module.bsl
+++ b/IRP/src/DocumentJournals/DocumentsForIncomingPayment/Forms/ChoiceForm/Module.bsl
@@ -28,3 +28,8 @@ Function GetSelectedData()
 	SelectedData.Insert("Amount", CurrentData.DocumentAmount);
 	Return SelectedData;
 EndFunction
+
+&AtServerNoContext
+Procedure ListOnGetDataAtServer(ItemName, Settings, Rows)
+	JorDocumentsServer.ListOnGetDataAtServer(ItemName, Settings, Rows);
+EndProcedure

--- a/IRP/src/DocumentJournals/DocumentsForOutgoingPayment/Forms/ChoiceForm/Form.form
+++ b/IRP/src/DocumentJournals/DocumentsForOutgoingPayment/Forms/ChoiceForm/Form.form
@@ -593,6 +593,10 @@
       <segments>List.DefaultPicture</segments>
     </rowPictureDataPath>
     <extInfo xsi:type="form:DynamicListTableExtInfo">
+      <handlers>
+        <event>OnGetDataAtServer</event>
+        <name>ListOnGetDataAtServer</name>
+      </handlers>
       <autoRefreshPeriod>60</autoRefreshPeriod>
       <period>
         <startDate>0001-01-01T00:00:00</startDate>
@@ -635,7 +639,6 @@
       <autoMaxWidth>true</autoMaxWidth>
       <autoMaxHeight>true</autoMaxHeight>
       <placementArea>UserCmds</placementArea>
-      <toolTipRepresentation>Auto</toolTipRepresentation>
       <representationInContextMenu>Auto</representationInContextMenu>
     </items>
     <visible>true</visible>

--- a/IRP/src/DocumentJournals/DocumentsForOutgoingPayment/Forms/ChoiceForm/Form.form
+++ b/IRP/src/DocumentJournals/DocumentsForOutgoingPayment/Forms/ChoiceForm/Form.form
@@ -38,6 +38,175 @@
       <currentRowUse>Auto</currentRowUse>
     </extInfo>
   </items>
+  <items xsi:type="form:FormGroup">
+    <name>GroupHeader</name>
+    <id>55</id>
+    <items xsi:type="form:Button">
+      <name>FormCommandSelect</name>
+      <id>25</id>
+      <visible>true</visible>
+      <enabled>true</enabled>
+      <userVisible>
+        <common>true</common>
+      </userVisible>
+      <extendedTooltip>
+        <name>FormCommandSelectExtendedTooltip</name>
+        <id>26</id>
+        <visible>true</visible>
+        <enabled>true</enabled>
+        <userVisible>
+          <common>true</common>
+        </userVisible>
+        <type>Label</type>
+        <autoMaxWidth>true</autoMaxWidth>
+        <autoMaxHeight>true</autoMaxHeight>
+        <extInfo xsi:type="form:LabelDecorationExtInfo">
+          <horizontalAlign>Left</horizontalAlign>
+        </extInfo>
+      </extendedTooltip>
+      <type>UsualButton</type>
+      <commandName>Form.Command.CommandSelect</commandName>
+      <representation>Auto</representation>
+      <defaultButton>true</defaultButton>
+      <autoMaxWidth>true</autoMaxWidth>
+      <autoMaxHeight>true</autoMaxHeight>
+      <placementArea>UserCmds</placementArea>
+      <representationInContextMenu>Auto</representationInContextMenu>
+    </items>
+    <items xsi:type="form:Decoration">
+      <name>HeaderSpace</name>
+      <id>57</id>
+      <title>
+        <key>en</key>
+        <value> </value>
+      </title>
+      <visible>true</visible>
+      <enabled>true</enabled>
+      <userVisible>
+        <common>true</common>
+      </userVisible>
+      <extendedTooltip>
+        <name>HeaderSpaceExtendedTooltip</name>
+        <id>59</id>
+        <visible>true</visible>
+        <enabled>true</enabled>
+        <userVisible>
+          <common>true</common>
+        </userVisible>
+        <type>Label</type>
+        <autoMaxWidth>true</autoMaxWidth>
+        <autoMaxHeight>true</autoMaxHeight>
+        <extInfo xsi:type="form:LabelDecorationExtInfo">
+          <horizontalAlign>Left</horizontalAlign>
+        </extInfo>
+      </extendedTooltip>
+      <contextMenu>
+        <name>HeaderSpaceContextMenu</name>
+        <id>58</id>
+        <visible>true</visible>
+        <enabled>true</enabled>
+        <userVisible>
+          <common>true</common>
+        </userVisible>
+        <autoFill>true</autoFill>
+      </contextMenu>
+      <type>Label</type>
+      <autoMaxHeight>true</autoMaxHeight>
+      <horizontalStretch>true</horizontalStretch>
+      <extInfo xsi:type="form:LabelDecorationExtInfo">
+        <horizontalAlign>Left</horizontalAlign>
+      </extInfo>
+    </items>
+    <items xsi:type="form:FormField">
+      <name>AmountByDocumentDate</name>
+      <id>52</id>
+      <title>
+        <key>en</key>
+        <value>Status</value>
+      </title>
+      <visible>true</visible>
+      <enabled>true</enabled>
+      <userVisible>
+        <common>true</common>
+      </userVisible>
+      <dataPath xsi:type="form:DataPath">
+        <segments>AmountByDocumentDate</segments>
+      </dataPath>
+      <handlers>
+        <event>OnChange</event>
+        <name>AmountByDocumentDateOnChange</name>
+      </handlers>
+      <extendedTooltip>
+        <name>AmountByDocumentDateExtendedTooltip</name>
+        <id>54</id>
+        <visible>true</visible>
+        <enabled>true</enabled>
+        <userVisible>
+          <common>true</common>
+        </userVisible>
+        <type>Label</type>
+        <autoMaxWidth>true</autoMaxWidth>
+        <autoMaxHeight>true</autoMaxHeight>
+        <extInfo xsi:type="form:LabelDecorationExtInfo">
+          <horizontalAlign>Left</horizontalAlign>
+        </extInfo>
+      </extendedTooltip>
+      <contextMenu>
+        <name>AmountByDocumentDateContextMenu</name>
+        <id>53</id>
+        <visible>true</visible>
+        <enabled>true</enabled>
+        <userVisible>
+          <common>true</common>
+        </userVisible>
+        <autoFill>true</autoFill>
+      </contextMenu>
+      <type>CheckBoxField</type>
+      <editMode>Enter</editMode>
+      <showInHeader>true</showInHeader>
+      <headerHorizontalAlign>Left</headerHorizontalAlign>
+      <showInFooter>true</showInFooter>
+      <extInfo xsi:type="form:CheckBoxFieldExtInfo">
+        <checkBoxType>Tumbler</checkBoxType>
+        <editFormat>
+          <key>en</key>
+          <value>BF='Current time'; BT='By document date'</value>
+        </editFormat>
+      </extInfo>
+    </items>
+    <visible>true</visible>
+    <enabled>true</enabled>
+    <userVisible>
+      <common>true</common>
+    </userVisible>
+    <title>
+      <key>en</key>
+      <value>Group of header</value>
+    </title>
+    <extendedTooltip>
+      <name>GroupHeaderExtendedTooltip</name>
+      <id>56</id>
+      <visible>true</visible>
+      <enabled>true</enabled>
+      <userVisible>
+        <common>true</common>
+      </userVisible>
+      <type>Label</type>
+      <autoMaxWidth>true</autoMaxWidth>
+      <autoMaxHeight>true</autoMaxHeight>
+      <extInfo xsi:type="form:LabelDecorationExtInfo">
+        <horizontalAlign>Left</horizontalAlign>
+      </extInfo>
+    </extendedTooltip>
+    <type>UsualGroup</type>
+    <extInfo xsi:type="form:UsualGroupExtInfo">
+      <group>AlwaysHorizontal</group>
+      <showLeftMargin>true</showLeftMargin>
+      <united>true</united>
+      <throughAlign>Auto</throughAlign>
+      <currentRowUse>Auto</currentRowUse>
+    </extInfo>
+  </items>
   <items xsi:type="form:Table">
     <name>List</name>
     <id>3</id>
@@ -610,37 +779,6 @@
   <autoCommandBar>
     <name>FormCommandBar</name>
     <id>-1</id>
-    <items xsi:type="form:Button">
-      <name>FormCommandSelect</name>
-      <id>25</id>
-      <visible>true</visible>
-      <enabled>true</enabled>
-      <userVisible>
-        <common>true</common>
-      </userVisible>
-      <extendedTooltip>
-        <name>FormCommandSelectExtendedTooltip</name>
-        <id>26</id>
-        <visible>true</visible>
-        <enabled>true</enabled>
-        <userVisible>
-          <common>true</common>
-        </userVisible>
-        <type>Label</type>
-        <autoMaxWidth>true</autoMaxWidth>
-        <autoMaxHeight>true</autoMaxHeight>
-        <extInfo xsi:type="form:LabelDecorationExtInfo">
-          <horizontalAlign>Left</horizontalAlign>
-        </extInfo>
-      </extendedTooltip>
-      <commandName>Form.Command.CommandSelect</commandName>
-      <representation>Auto</representation>
-      <defaultButton>true</defaultButton>
-      <autoMaxWidth>true</autoMaxWidth>
-      <autoMaxHeight>true</autoMaxHeight>
-      <placementArea>UserCmds</placementArea>
-      <representationInContextMenu>Auto</representationInContextMenu>
-    </items>
     <visible>true</visible>
     <enabled>true</enabled>
     <userVisible>
@@ -689,6 +827,23 @@ FROM
       <autoSaveUserSettings>true</autoSaveUserSettings>
       <getInvisibleFieldPresentations>true</getInvisibleFieldPresentations>
     </extInfo>
+  </attributes>
+  <attributes>
+    <name>AmountByDocumentDate</name>
+    <title>
+      <key>en</key>
+      <value>Amount by document date</value>
+    </title>
+    <id>2</id>
+    <valueType>
+      <types>Boolean</types>
+    </valueType>
+    <view>
+      <common>true</common>
+    </view>
+    <edit>
+      <common>true</common>
+    </edit>
   </attributes>
   <formCommands>
     <name>CommandSelect</name>

--- a/IRP/src/DocumentJournals/DocumentsForOutgoingPayment/Forms/ChoiceForm/Module.bsl
+++ b/IRP/src/DocumentJournals/DocumentsForOutgoingPayment/Forms/ChoiceForm/Module.bsl
@@ -33,3 +33,8 @@ EndFunction
 Procedure ListOnGetDataAtServer(ItemName, Settings, Rows)
 	JorDocumentsServer.ListOnGetDataAtServer(ItemName, Settings, Rows);
 EndProcedure
+
+&AtClient
+Procedure AmountByDocumentDateOnChange(Item)
+	JorDocumentsClientServer.SetPeriodInDynamicList(List, AmountByDocumentDate);
+EndProcedure

--- a/IRP/src/DocumentJournals/DocumentsForOutgoingPayment/Forms/ChoiceForm/Module.bsl
+++ b/IRP/src/DocumentJournals/DocumentsForOutgoingPayment/Forms/ChoiceForm/Module.bsl
@@ -28,3 +28,8 @@ Function GetSelectedData()
 	SelectedData.Insert("Amount", CurrentData.DocumentAmount);
 	Return SelectedData;
 EndFunction
+
+&AtServerNoContext
+Procedure ListOnGetDataAtServer(ItemName, Settings, Rows)
+	JorDocumentsServer.ListOnGetDataAtServer(ItemName, Settings, Rows);
+EndProcedure

--- a/features/Internal/_0500 Cash management/_0500PostingCashReciept.feature
+++ b/features/Internal/_0500 Cash management/_0500PostingCashReciept.feature
@@ -164,7 +164,7 @@ Scenario: _050001 create Cash receipt based on Sales invoice
 
 
 
-Scenario: _050001 create Cash receipt (independently)
+Scenario: _0500011 create Cash receipt (independently)
 	* Create Cash receipt in lire for Ferron BP (Sales invoice in lire)
 		Given I open hyperlink "e1cib/list/Document.CashReceipt"
 		And I click the button named "FormCreate"
@@ -364,8 +364,97 @@ Scenario: _050001 create Cash receipt (independently)
 			|  '$$NumberCashReceipt0500013$$'    |
 
 
-	
-
+Scenario: _0500012 check form for select basis document	
+		And I close all client application windows
+	* Create Cash receipt in lire for Ferron BP (Sales invoice in lire)
+		Given I open hyperlink "e1cib/list/Document.CashReceipt"
+		And I click the button named "FormCreate"
+		* Filling in the details of the document
+			And I select "Payment from customer" exact value from "Transaction type" drop-down list
+			And I click Select button of "Company" field
+			And I go to line in "List" table
+				| Description  |
+				| Main Company |
+			And I select current line in "List" table
+			And I click Select button of "Currency" field
+			And I activate "Description" field in "List" table
+			And I go to line in "List" table
+				| Code | Description  |
+				| TRY  | Turkish lira |
+			And I select current line in "List" table
+			And I click Select button of "Cash account" field
+			And I go to line in "List" table
+				| Description    |
+				| Cash desk №1 |
+			And I select current line in "List" table
+		And in the table "PaymentList" I click the button named "PaymentListAdd"
+		* Filling in a partner in a tabular part
+			And I activate "Partner" field in "PaymentList" table
+			And I click choice button of "Partner" attribute in "PaymentList" table
+			And I go to line in "List" table
+				| Description |
+				| Ferron BP   |
+			And I select current line in "List" table
+			And I click choice button of "Payer" attribute in "PaymentList" table
+			And I go to line in "List" table
+				| Description       |
+				| Company Ferron BP |
+			And I select current line in "List" table
+		* Filling in an Partner term
+			And I click choice button of "Partner term" attribute in "PaymentList" table
+			And I go to line in "List" table
+				| 'Description'           |
+				| 'Basic Partner terms, TRY' |
+			And I select current line in "List" table
+		* Check forms DocumentsForIncomingPayment (current time)
+			And I finish line editing in "PaymentList" table
+			And I activate "Basis document" field in "PaymentList" table
+			And I select current line in "PaymentList" table
+			And "List" table contains lines
+				| 'Document'         | 'Company'      | 'Partner'   | 'Amount'   | 'Legal name'        | 'Partner term'             | 'Currency' |
+				| 'Sales invoice 1*' | 'Main Company' | 'Ferron BP' | '4 250,00' | 'Company Ferron BP' | 'Basic Partner terms, TRY' | 'TRY'      |
+			And I click "Select" button
+			And I activate field named "PaymentListTotalAmount" in "PaymentList" table
+			And I input "100,00" text in the field named "PaymentListTotalAmount" of "PaymentList" table
+			And I finish line editing in "PaymentList" table
+			And in the table "PaymentList" I click the button named "PaymentListAdd"
+			And I activate "Partner" field in "PaymentList" table
+			And I click choice button of "Partner" attribute in "PaymentList" table
+			And I go to line in "List" table
+				| 'Code' | 'Description' |
+				| '1'    | 'Ferron BP'   |
+			And I select current line in "List" table
+			And I activate "Partner term" field in "PaymentList" table
+			And I click choice button of "Partner term" attribute in "PaymentList" table
+			And I go to line in "List" table
+				| 'Description'              |
+				| 'Basic Partner terms, TRY' |
+			And I select current line in "List" table
+			And I finish line editing in "PaymentList" table
+			And I activate "Basis document" field in "PaymentList" table
+			And I select current line in "PaymentList" table
+			And "List" table contains lines
+				| 'Document'         | 'Company'      | 'Partner'   | 'Amount'   | 'Legal name'        | 'Partner term'             | 'Currency' |
+				| 'Sales invoice 1*' | 'Main Company' | 'Ferron BP' | '4 150,00' | 'Company Ferron BP' | 'Basic Partner terms, TRY' | 'TRY'      |
+			And I close current window
+		* Check forms DocumentsForIncomingPayment (by document date)
+			And I input "{CurrentDate() - 86401}" text in the field named "Date"
+			And I move to "Payments" tab
+			And I go to line in "PaymentList" table
+				| '#' | 'Partner'   | 'Partner term'             | 'Payer'             |
+				| '2' | 'Ferron BP' | 'Basic Partner terms, TRY' | 'Company Ferron BP' |
+			And I finish line editing in "PaymentList" table
+			And I activate "Basis document" field in "PaymentList" table
+			And I select current line in "PaymentList" table
+			And I change "Status" radio button value to "By document date"
+			Then the number of "List" table lines is "равно" 0
+			And I change "Status" radio button value to "Current time"
+			And "List" table contains lines
+				| 'Document'         | 'Company'      | 'Partner'   | 'Amount'   | 'Legal name'        | 'Partner term'             | 'Currency' |
+				| 'Sales invoice 1*' | 'Main Company' | 'Ferron BP' | '4 150,00' | 'Company Ferron BP' | 'Basic Partner terms, TRY' | 'TRY'      |
+		And I close all client application windows
+		
+		
 
 # Filters
 

--- a/features/Internal/_0500 Cash management/_0510PostingCashPayment.feature
+++ b/features/Internal/_0500 Cash management/_0510PostingCashPayment.feature
@@ -152,7 +152,7 @@ Scenario: _051001 create Cash payment based on Purchase invoice
 
 
 
-Scenario: _051001 create Cash payment (independently)
+Scenario: _0510011 create Cash payment (independently)
 	* Create Cash payment in lire for Ferron BP (Sales invoice in lire)
 		Given I open hyperlink "e1cib/list/Document.CashPayment"
 		And I click the button named "FormCreate"
@@ -338,7 +338,101 @@ Scenario: _051001 create Cash payment (independently)
 			| 'Number' |
 			| '$$NumberCashPayment0510013$$'    |	
 	
-	
+Scenario: _0510012 check form for select basis document	
+		And I close all client application windows
+	* Create Cash payment in lire for Ferron BP (Purchase invoice in lire)
+		Given I open hyperlink "e1cib/list/Document.CashPayment"
+		And I click the button named "FormCreate"
+		* Filling in the details of the document
+			And I select "Payment to the vendor" exact value from "Transaction type" drop-down list
+			And I click Select button of "Company" field
+			And I go to line in "List" table
+				| Description  |
+				| Main Company |
+			And I select current line in "List" table
+			And I click Select button of "Currency" field
+			And I activate "Description" field in "List" table
+			And I go to line in "List" table
+				| Code | Description  |
+				| TRY  | Turkish lira |
+			And I select current line in "List" table
+			And I click Select button of "Cash account" field
+			And I go to line in "List" table
+				| Description    |
+				| Cash desk №1 |
+			And I select current line in "List" table
+		And in the table "PaymentList" I click the button named "PaymentListAdd"
+		* Filling in a partner in a tabular part
+			And I activate "Partner" field in "PaymentList" table
+			And I click choice button of "Partner" attribute in "PaymentList" table
+			And I go to line in "List" table
+				| Description |
+				| Ferron BP   |
+			And I select current line in "List" table
+			And I click choice button of "Payee" attribute in "PaymentList" table
+			And I go to line in "List" table
+				| Description       |
+				| Company Ferron BP |
+			And I select current line in "List" table
+		* Filling in an Partner term
+			And I click choice button of "Partner term" attribute in "PaymentList" table
+			And I go to line in "List" table
+				| 'Description'           |
+				| 'Vendor Ferron, TRY' |
+			And I select current line in "List" table
+		* Check forms DocumentsForOutgoingPayment (current time)
+			And I finish line editing in "PaymentList" table
+			And I activate "Basis document" field in "PaymentList" table
+			And I select current line in "PaymentList" table
+			And "List" table contains lines
+				| 'Document'            | 'Company'      | 'Partner'   | 'Amount'     | 'Legal name'        | 'Partner term'       | 'Currency' |
+				| 'Purchase invoice 1*' | 'Main Company' | 'Ferron BP' | '136 000,00' | 'Company Ferron BP' | 'Vendor Ferron, TRY' | 'TRY'      |
+				| 'Purchase invoice 2*' | 'Main Company' | 'Ferron BP' | '13 000,00'  | 'Company Ferron BP' | 'Vendor Ferron, TRY' | 'TRY'      |
+			And I go to line in "List" table
+				| 'Amount'     |
+				| '136 000,00' |
+			And I click "Select" button
+			And I activate field named "PaymentListTotalAmount" in "PaymentList" table
+			And I input "100,00" text in the field named "PaymentListTotalAmount" of "PaymentList" table
+			And I finish line editing in "PaymentList" table
+			And in the table "PaymentList" I click the button named "PaymentListAdd"
+			And I activate "Partner" field in "PaymentList" table
+			And I click choice button of "Partner" attribute in "PaymentList" table
+			And I go to line in "List" table
+				| 'Code' | 'Description' |
+				| '1'    | 'Ferron BP'   |
+			And I select current line in "List" table
+			And I activate "Partner term" field in "PaymentList" table
+			And I click choice button of "Partner term" attribute in "PaymentList" table
+			And I go to line in "List" table
+				| 'Description'           |
+				| 'Vendor Ferron, TRY' |
+			And I select current line in "List" table
+			And I finish line editing in "PaymentList" table
+			And I activate "Basis document" field in "PaymentList" table
+			And I select current line in "PaymentList" table
+			And "List" table contains lines
+				| 'Document'            | 'Company'      | 'Partner'   | 'Amount'     | 'Legal name'        | 'Partner term'       | 'Currency' |
+				| 'Purchase invoice 1*' | 'Main Company' | 'Ferron BP' | '135 900,00' | 'Company Ferron BP' | 'Vendor Ferron, TRY' | 'TRY'      |
+				| 'Purchase invoice 2*' | 'Main Company' | 'Ferron BP' | '13 000,00'  | 'Company Ferron BP' | 'Vendor Ferron, TRY' | 'TRY'      |
+			And I close current window
+		* Check forms DocumentsForIncomingPayment (by document date)
+			And I input "{CurrentDate() - 86401}" text in the field named "Date"
+			And I move to "Payments" tab
+			And I go to line in "PaymentList" table
+				| '#' | 'Partner'   | 'Partner term'       | 'Payee'             |
+				| '2' | 'Ferron BP' | 'Vendor Ferron, TRY' | 'Company Ferron BP' |
+			And I finish line editing in "PaymentList" table
+			And I activate "Basis document" field in "PaymentList" table
+			And I select current line in "PaymentList" table
+			And I change "Status" radio button value to "By document date"
+			Then the number of "List" table lines is "равно" 0
+			And I change "Status" radio button value to "Current time"
+			And "List" table contains lines
+				| 'Document'            | 'Company'      | 'Partner'   | 'Amount'     | 'Legal name'        | 'Partner term'       | 'Currency' |
+				| 'Purchase invoice 1*' | 'Main Company' | 'Ferron BP' | '135 900,00' | 'Company Ferron BP' | 'Vendor Ferron, TRY' | 'TRY'      |
+				| 'Purchase invoice 2*' | 'Main Company' | 'Ferron BP' | '13 000,00'  | 'Company Ferron BP' | 'Vendor Ferron, TRY' | 'TRY'      |
+		And I close all client application windows	
 
 # Filters
 


### PR DESCRIPTION
Сделал, как написали @bryaleks и @andreyvorobyov2 

Но лично для меня это как-то странно по нескольким причинам:
1. Если случайно уберут строку с ранее использованным документом, то не смогут ее вернуть не отменив проведение. А если отменять проведение, то старое и новое поведение будут идентичны.
2. В фильтре для подбора в CP используется остаток по R2021B_CustomersTransactions, но в моей базе этот документ не делал сюда проводок (согласно кода проводки делаются только в некоторых вариантах с возвратами и авансами).
3. Почему вообще возвращаются в "старые" ранее проведенные документы и их меняют? Если тут есть определенная бизнес-логика, то может это действие не должно быть ручным? (а из отчета или обработки)

Так же возможен вариант устойчивый к состоянию "проведенности" - передавать в запрос временную таблицу с текущим содержанием документов, чтобы на указанные суммы уменьшать доступный остаток. В этом случае нужно будет вернуть Excluding.