### PR TITLE
Grouping when uploading from excel  #1844

### DIFF
--- a/IRP/src/CommonForms/PickupItems/Form.form
+++ b/IRP/src/CommonForms/PickupItems/Form.form
@@ -2109,6 +2109,23 @@
         <common>true</common>
       </edit>
     </columns>
+    <columns>
+      <name>AlwaysAddNewRowAfterScan</name>
+      <title>
+        <key>en</key>
+        <value>Always add new row after scan</value>
+      </title>
+      <id>41</id>
+      <valueType>
+        <types>Boolean</types>
+      </valueType>
+      <view>
+        <common>true</common>
+      </view>
+      <edit>
+        <common>true</common>
+      </edit>
+    </columns>
   </attributes>
   <attributes>
     <name>ItemList</name>
@@ -2508,6 +2525,23 @@
       <id>40</id>
       <valueType>
         <types>CatalogRef.SourceOfOrigins</types>
+      </valueType>
+      <view>
+        <common>true</common>
+      </view>
+      <edit>
+        <common>true</common>
+      </edit>
+    </columns>
+    <columns>
+      <name>AlwaysAddNewRowAfterScan</name>
+      <title>
+        <key>en</key>
+        <value>Always add new row after scan</value>
+      </title>
+      <id>42</id>
+      <valueType>
+        <types>Boolean</types>
       </valueType>
       <view>
         <common>true</common>

--- a/IRP/src/CommonForms/PickupItems/Module.bsl
+++ b/IRP/src/CommonForms/PickupItems/Module.bsl
@@ -138,7 +138,8 @@ Procedure ItemTypeAfterSelection()
 				|	&PriceType AS PriceType,
 				|	0 AS Price,
 				|	Items.Item.Description_en AS ItemPresentation,
-				|	Items.Item.ItemType.Type = Value(Enum.ItemTypes.Service) AS isService
+				|	Items.Item.ItemType.Type = Value(Enum.ItemTypes.Service) AS isService,
+				|	Items.Item.ItemType.AlwaysAddNewRowAfterScan AS AlwaysAddNewRowAfterScan
 				|FROM
 				|	Items AS Items
 				|		LEFT JOIN ItemBalance AS ItemBalance
@@ -364,7 +365,8 @@ Function ItemListSelectionAfter(ParametersStructure)
 				 |	ItemKeyTempTable.ItemType.UseSerialLotNumber AS UseSerialLotNumber,
 				 |	NULL AS SerialLotNumber,
 				 |	PricesResult.Price,
-				 |	ItemKeyTempTable.ItemKey.Item.ItemType.Type = Value(Enum.ItemTypes.Service) AS isService
+				 |	ItemKeyTempTable.ItemKey.Item.ItemType.Type = Value(Enum.ItemTypes.Service) AS isService,
+				 |	ItemKeyTempTable.ItemKey.Item.ItemType.AlwaysAddNewRowAfterScan AS AlwaysAddNewRowAfterScan
 				 |FROM
 				 |	ItemKeyTempTable AS ItemKeyTempTable
 				 |		LEFT JOIN AccumulationRegister.R4011B_FreeStocks.Balance(&EndPeriod, Store IN (&Stores)
@@ -400,6 +402,7 @@ Function ItemListSelectionAfter(ParametersStructure)
 			TransferParameters.Insert("UseSerialLotNumber", QuerySelection.UseSerialLotNumber);
 			TransferParameters.Insert("SerialLotNumber", QuerySelection.SerialLotNumber);
 			TransferParameters.Insert("isService", QuerySelection.isService);
+			TransferParameters.Insert("AlwaysAddNewRowAfterScan", QuerySelection.AlwaysAddNewRowAfterScan);
 			ItemKeyListSelectionAfter(TransferParameters);
 		Else
 			While QuerySelection.Next() Do
@@ -414,6 +417,7 @@ Function ItemListSelectionAfter(ParametersStructure)
 				NewRow.UseSerialLotNumber = QuerySelection.UseSerialLotNumber;
 				NewRow.SerialLotNumber = QuerySelection.SerialLotNumber;
 				NewRow.isService = QuerySelection.isService;
+				NewRow.AlwaysAddNewRowAfterScan = QuerySelection.AlwaysAddNewRowAfterScan;
 			EndDo;
 		EndIf;
 	EndIf;
@@ -437,7 +441,7 @@ EndProcedure
 Procedure CommandSaveAndClose(Command)
 	ArrayOfResults = New Array();
 	For Each Row In ThisObject.ItemTableValue Do
-		Result = New Structure("Item, ItemKey, Quantity, Unit, SerialLotNumber, UseSerialLotNumber, IsService, SourceOfOrigin");
+		Result = New Structure("Item, ItemKey, Quantity, Unit, SerialLotNumber, UseSerialLotNumber, IsService, SourceOfOrigin, AlwaysAddNewRowAfterScan");
 		FillPropertyValues(Result, Row);
 		Result.Insert("PriceType", ThisObject.PriceType);
 		ArrayOfResults.Add(Result);

--- a/IRP/src/CommonModules/ControllerServer_V2/Module.bsl
+++ b/IRP/src/CommonModules/ControllerServer_V2/Module.bsl
@@ -21,6 +21,15 @@ Function GetServerData(Object, ArrayOfTableNames, FormTaxColumnsExists, TaxesCac
 	
 	SerialLotNumberExists = ServerData.ObjectMetadataInfo.Tables.Property("SerialLotNumbers");
 	
+	If Not SerialLotNumberExists Then
+		ObjectRefType = TypeOf(Object.Ref);
+	
+		If ObjectRefType = Type("DocumentRef.PhysicalInventory")
+			Or ObjectRefType = Type("DocumentRef.PhysicalCountByLocation") Then
+			SerialLotNumberExists = Object.UseSerialLot;
+		EndIf;
+	EndIf;
+	
 	If  ValueIsFilled(LoadParameters.Address) Then
 		SourceTable = GetFromTempStorage(LoadParameters.Address);
 		SourceTableCopy = SourceTable.Copy();
@@ -32,7 +41,7 @@ Function GetServerData(Object, ArrayOfTableNames, FormTaxColumnsExists, TaxesCac
 			GroupColumns = "Item, ItemKey, Unit"; // all defined columns in GetItemInfo.GetTableOfResults
 		EndIf;
 		
-		If Not SerialLotNumberExists And SourceTableCopy.Columns.Find("SerialLotNumber") <> Undefined Then
+		If SerialLotNumberExists And SourceTableCopy.Columns.Find("SerialLotNumber") <> Undefined Then
 			GroupColumns = GroupColumns + ", SerialLotNumber";
 		EndIf;
 		
@@ -62,7 +71,7 @@ Function GetServerData(Object, ArrayOfTableNames, FormTaxColumnsExists, TaxesCac
 			ItemKeyTable.GroupBy("ItemKey");
 		
 			For Each RowItemKey In ItemKeyTable Do
-				If RowItemKey.ItemKey.Item.ItemType.NotUseLineGrouping Then
+				If RowItemKey.ItemKey.Item.ItemType.NotUseLineGrouping And SerialLotNumberExists Then
 					SourceTableRows = SourceTable.FindRows(New Structure("ItemKey", RowItemKey.ItemKey));
 					For Each Row In SourceTableRows Do
 						FillPropertyValues(SourceTableBuffer.Add(), Row);

--- a/IRP/src/CommonModules/DocumentsClient/Module.bsl
+++ b/IRP/src/CommonModules/DocumentsClient/Module.bsl
@@ -527,8 +527,10 @@ Procedure PickupItemsEnd(Result, AddInfo) Export
 	
 	ObjectRefType = TypeOf(Object.Ref);
 	
-	isSerialLotNumberAtRow = ObjectRefType = Type("DocumentRef.PhysicalInventory")
-			Or ObjectRefType = Type("DocumentRef.PhysicalCountByLocation");
+	If ObjectRefType = Type("DocumentRef.PhysicalInventory")
+		Or ObjectRefType = Type("DocumentRef.PhysicalCountByLocation") Then
+		isSerialLotNumberAtRow = Object.UseSerialLot;
+	EndIf;
 	
 	If Object.Property("Agreement") Then
 		FilterString = "Item, ItemKey, Unit, PriceType";
@@ -590,7 +592,7 @@ Procedure PickupItemsEnd(Result, AddInfo) Export
 		EndIf;
 		
 		AddToExistsRow = ExistingRows.Count() > 0;
-		If UseSerialLotNumbers Then
+		If UseSerialLotNumbers Or isSerialLotNumberAtRow Then
 			If ResultElement.AlwaysAddNewRowAfterScan Then
 				AddToExistsRow = False;
 			EndIf;

--- a/IRP/src/CommonModules/DocumentsClient/Module.bsl
+++ b/IRP/src/CommonModules/DocumentsClient/Module.bsl
@@ -589,7 +589,14 @@ Procedure PickupItemsEnd(Result, AddInfo) Export
 			ExistingRows = Object.ItemList.FindRows(FilledFilter);	
 		EndIf;
 		
-		If ExistingRows.Count() And Not ResultElement.AlwaysAddNewRowAfterScan Then // increment Quantity in existing row
+		AddToExistsRow = ExistingRows.Count() > 0;
+		If UseSerialLotNumbers Then
+			If ResultElement.AlwaysAddNewRowAfterScan Then
+				AddToExistsRow = False;
+			EndIf;
+		EndIf;
+		
+		If AddToExistsRow Then // increment Quantity in existing row
 			Row = ExistingRows[0];
 			
 			_UpdateQuantity = True;

--- a/features/Internal/_2000 LoadInfo/_2010LoadDataForm.feature
+++ b/features/Internal/_2000 LoadInfo/_2010LoadDataForm.feature
@@ -939,9 +939,191 @@ Scenario: _020140 load data in the SI (each sln new row, load by barcode)
 		And I close all client application windows	
 				
 		
-				
+
+Scenario: _020141 load data in the SO (each sln new row, load by barcode)
+		And I close all client application windows
+	* Open Sales order
+		Given I open hyperlink "e1cib/list/Document.SalesOrder"
+		And I click the button named "FormCreate"
+	* Check load data form
+		And in the table "ItemList" I click "Load data from table" button	
+	* Add barcodes
+		And in "Template" spreadsheet document I move to "R3C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009098"
+		And in "Template" spreadsheet document I move to "R3C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "2"
+		And in "Template" spreadsheet document I move to "R4C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009099"
+		And in "Template" spreadsheet document I move to "R4C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "1"
+		And in "Template" spreadsheet document I move to "R5C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009100"
+		And in "Template" spreadsheet document I move to "R5C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "1"
+		And I click "Next" button
+		And I click "Next" button
+	* Check document
+		And "ItemList" table became equal
+			| 'Procurement method' | 'Item key' | 'Quantity' | 'Unit' | 'Item'                         |
+			| 'Stock'              | 'PZU'      | '3,000'    | 'pcs'  | 'Product 7 with SLN (new row)' |
+			| 'Stock'              | 'ODS'      | '1,000'    | 'pcs'  | 'Product 7 with SLN (new row)' |
+		And I close all client application windows
 		
 		
+
+Scenario: _020142 load data in the PhysicalInventory (each sln new row, use serial lot)
+		And I close all client application windows
+	* Open Physical inventory
+		Given I open hyperlink "e1cib/list/Document.PhysicalInventory"
+		And I click the button named "FormCreate"
+		And I set checkbox "Use serial lot"
+	* Check load data form
+		And in the table "ItemList" I click "Load data from table" button	
+	* Add barcodes
+		And in "Template" spreadsheet document I move to "R3C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009098"
+		And in "Template" spreadsheet document I move to "R3C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "2"
+		And in "Template" spreadsheet document I move to "R4C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009099"
+		And in "Template" spreadsheet document I move to "R4C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "1"
+		And in "Template" spreadsheet document I move to "R5C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009100"
+		And in "Template" spreadsheet document I move to "R5C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "1"
+		And I click "Next" button
+		And I click "Next" button
+	* Check document
+		And "ItemList" table became equal
+			| 'Item'                         | 'Item key' | 'Unit' | 'Serial lot number'  | 'Phys. count'|
+			| 'Product 7 with SLN (new row)' | 'PZU'      | 'pcs'  | '9009098'            | '2,000'      |
+			| 'Product 7 with SLN (new row)' | 'PZU'      | 'pcs'  | '9009099'            | '1,000'      |
+			| 'Product 7 with SLN (new row)' | 'ODS'      | 'pcs'  | '9009100'            | '1,000'      |
+		And I close all client application windows	
+
+
+Scenario: _020143 load data in the PhysicalInventory (each sln new row, not use serial lot)
+		And I close all client application windows
+	* Open Physical inventory
+		Given I open hyperlink "e1cib/list/Document.PhysicalInventory"
+		And I click the button named "FormCreate"
+	* Check load data form
+		And in the table "ItemList" I click "Load data from table" button	
+	* Add barcodes
+		And in "Template" spreadsheet document I move to "R3C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009098"
+		And in "Template" spreadsheet document I move to "R3C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "2"
+		And in "Template" spreadsheet document I move to "R4C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009099"
+		And in "Template" spreadsheet document I move to "R4C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "1"
+		And in "Template" spreadsheet document I move to "R5C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009100"
+		And in "Template" spreadsheet document I move to "R5C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "1"
+		And I click "Next" button
+		And I click "Next" button
+	* Check document
+		And "ItemList" table became equal
+			| 'Item'                         | 'Item key' | 'Unit' | 'Serial lot number' | 'Phys. count' |
+			| 'Product 7 with SLN (new row)' | 'PZU'      | 'pcs'  | ''                  | '3,000'       |
+			| 'Product 7 with SLN (new row)' | 'ODS'      | 'pcs'  | ''                  | '1,000'       |
+		And I close all client application windows				
+								
+		
+
+Scenario: _020144 load data in the PhysicalCountByLocation (each sln new row, use serial lot)
+		And I close all client application windows
+	* Open PhysicalCountByLocation
+		Given I open hyperlink "e1cib/list/Document.PhysicalCountByLocation"
+		And I click the button named "FormCreate"
+		And I set checkbox "Use serial lot"
+	* Check load data form
+		And in the table "ItemList" I click "Load data from table" button	
+	* Add barcodes
+		And in "Template" spreadsheet document I move to "R3C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009098"
+		And in "Template" spreadsheet document I move to "R3C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "2"
+		And in "Template" spreadsheet document I move to "R4C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009099"
+		And in "Template" spreadsheet document I move to "R4C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "1"
+		And in "Template" spreadsheet document I move to "R5C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009100"
+		And in "Template" spreadsheet document I move to "R5C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "1"
+		And I click "Next" button
+		And I click "Next" button
+	* Check document
+		And "ItemList" table became equal
+			| 'Item'                         | 'Item key' | 'Unit' | 'Serial lot number'  | 'Phys. count'|
+			| 'Product 7 with SLN (new row)' | 'PZU'      | 'pcs'  | '9009098'            | '2,000'      |
+			| 'Product 7 with SLN (new row)' | 'PZU'      | 'pcs'  | '9009099'            | '1,000'      |
+			| 'Product 7 with SLN (new row)' | 'ODS'      | 'pcs'  | '9009100'            | '1,000'      |
+		And I close all client application windows	
+
+
+Scenario: _020145 load data in the PhysicalCountByLocation (each sln new row, not use serial lot)
+		And I close all client application windows
+	* Open PhysicalCountByLocation
+		Given I open hyperlink "e1cib/list/Document.PhysicalCountByLocation"
+		And I click the button named "FormCreate"
+	* Check load data form
+		And in the table "ItemList" I click "Load data from table" button	
+	* Add barcodes
+		And in "Template" spreadsheet document I move to "R3C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009098"
+		And in "Template" spreadsheet document I move to "R3C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "2"
+		And in "Template" spreadsheet document I move to "R4C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009099"
+		And in "Template" spreadsheet document I move to "R4C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "1"
+		And in "Template" spreadsheet document I move to "R5C1" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "9009100"
+		And in "Template" spreadsheet document I move to "R5C2" cell
+		And in "Template" spreadsheet document I double-click the current cell
+		And in "Template" spreadsheet document I input text "1"
+		And I click "Next" button
+		And I click "Next" button
+	* Check document
+		And "ItemList" table became equal
+			| 'Item'                         | 'Item key' | 'Unit' | 'Serial lot number' | 'Phys. count' |
+			| 'Product 7 with SLN (new row)' | 'PZU'      | 'pcs'  | ''                  | '3,000'       |
+			| 'Product 7 with SLN (new row)' | 'ODS'      | 'pcs'  | ''                  | '1,000'       |
+		And I close all client application windows						
 				
 		
 				


### PR DESCRIPTION
fixed #1844

Теперь система проверяет, что если в документе нет серийников, то тогда игнорируется настройка AlwaysAddNewRowAfterScan при сканировании товаров.
И игнорируется настройка NotUseLineGrouping при загрузке из табличного документа.

Также пофиксил ошибки с инвентами и каунтами. Так как там по умолчанию ставилось что серийник есть, даже если галочка - учет серийников в самом документе была выключена.

По тестам надо добавить проверку в SO, SI, PhInv. CBL
Для последних двух надо протестить и сканирование и загрузку в случаях когда галочка учета по серийникам включена, а потом когда выключена. Если она выключена - строки должны группироваться.