### PR TITLE
#2213 don't launch scheduler job on disable ext.function

### DIFF
--- a/IRP/src/Catalogs/ExternalFunctions/ObjectModule.bsl
+++ b/IRP/src/Catalogs/ExternalFunctions/ObjectModule.bsl
@@ -1,5 +1,15 @@
 // @strict-types
 
+Procedure BeforeWrite(Cancel)
+	If DataExchange.Load Then
+		Return;
+	EndIf;
+
+	If Not IsFolder And DeletionMark Then
+		Enable = False;
+	EndIf;
+EndProcedure
+
 Procedure OnWrite(Cancel)
 	If DataExchange.Load Then
 		Return;

--- a/IRP/src/CommonModules/CommonFunctionsServer/Module.bsl
+++ b/IRP/src/CommonModules/CommonFunctionsServer/Module.bsl
@@ -1027,7 +1027,7 @@ EndFunction
 //  ExternalFunction - CatalogRef.ExternalFunctions - External function
 Procedure CreateScheduledJob(ExternalFunction) Export
 	
-	If Not ExternalFunction.isSchedulerSet Then
+	If Not ExternalFunction.isSchedulerSet Or Not ExternalFunction.Enable Then
 		DeleteScheduledJob(ExternalFunction);
 		Return;
 	EndIf;


### PR DESCRIPTION
1. При пометке на удаление делаю функцию неактивной.
2. Перед запуском регламентного задания проверяю не только флаг регламентных заданий, но и флаг активности.

Была мысль при смене активности явно отключить запуск регламентных заданий, но отказался. Флаг включенного регламентного задания можно использовать для фильтра в списке, а если бы пользователю этот флаг был не нужен, то он бы сам его явно снял.