### PR TITLE
Fix Consignor VAT after scan

### DIFF
--- a/IRP/src/CommonModules/DocumentsServer/Module.bsl
+++ b/IRP/src/CommonModules/DocumentsServer/Module.bsl
@@ -771,6 +771,9 @@ Function PickupItemEnd(Val Parameters, Val ScanData) Export
 											ItemListRow.Insert("Consignor", InfoRow.Consignor);
 										EndIf;
 										
+										If InfoRow.Property("VatRate") Then
+											ItemListRow.Insert("VatRate", InfoRow.VatRate);
+										EndIf;										
 									EndIf;
 								EndDo;
 							EndIf;


### PR DESCRIPTION
При выборе в ручную товар с серией, которая от комисионера - ндс меняет.
При сканирование - вид запасов меняет, а вот НДС оставляет 20%