### PR TITLE
#GEN-114 Journal Entries are not created for some Ext acc operations

### DIFF
--- a/IRP/src/CommonModules/AccountingServer/Module.bsl
+++ b/IRP/src/CommonModules/AccountingServer/Module.bsl
@@ -2657,6 +2657,7 @@ Function GetTableOfJEDocuments(ArrayOfBasisDocuments, ArrayOfLedgerTypes) Export
 	For Each Row In QueryTable Do
 		If ValueIsFilled(Row.JournalEntry) Then
 			JEDocObject = Row.JournalEntry.GetObject();
+			JEDocObject.DeletionMark = False;
 		Else
 			JEDocObject = Documents.JournalEntry.CreateDocument();
 		EndIf;


### PR DESCRIPTION
Если JE был создан раннее и помечен на удаление, то при повторной загрузке EAO, JE не заполняется проводками. Исправлено.