### PR TITLE
Restrict delete rights for new objects in roles

### DIFF
--- a/IRP/src/Roles/FullAccess/Rights.rights
+++ b/IRP/src/Roles/FullAccess/Rights.rights
@@ -267,6 +267,13 @@
 		</right>
 	</object>
 	<object>
+		<name>Task.ExecutorTasks</name>
+		<right>
+			<name>InteractiveDelete</name>
+			<value>false</value>
+		</right>
+	</object>
+	<object>
 		<name>Document.MoneyTransfer</name>
 		<right>
 			<name>InteractiveDelete</name>
@@ -482,6 +489,13 @@
 		</right>
 		<right>
 			<name>InteractiveDeleteMarkedPredefinedData</name>
+			<value>false</value>
+		</right>
+	</object>
+	<object>
+		<name>BusinessProcess.ExecutionProcesses</name>
+		<right>
+			<name>InteractiveDelete</name>
 			<value>false</value>
 		</right>
 	</object>
@@ -2570,6 +2584,17 @@
 		</right>
 		<right>
 			<name>InteractiveDeleteMarkedPredefinedData</name>
+			<value>false</value>
+		</right>
+	</object>
+	<object>
+		<name>Catalog.ExecutionTemplates</name>
+		<right>
+			<name>InteractiveDelete</name>
+			<value>false</value>
+		</right>
+		<right>
+			<name>InteractiveDeletePredefinedData</name>
 			<value>false</value>
 		</right>
 	</object>

--- a/IRP/src/Roles/FullAccessNoAdminFunctions/Rights.rights
+++ b/IRP/src/Roles/FullAccessNoAdminFunctions/Rights.rights
@@ -267,6 +267,13 @@
 		</right>
 	</object>
 	<object>
+		<name>Task.ExecutorTasks</name>
+		<right>
+			<name>InteractiveDelete</name>
+			<value>false</value>
+		</right>
+	</object>
+	<object>
 		<name>Document.MoneyTransfer</name>
 		<right>
 			<name>InteractiveDelete</name>
@@ -482,6 +489,13 @@
 		</right>
 		<right>
 			<name>InteractiveDeleteMarkedPredefinedData</name>
+			<value>false</value>
+		</right>
+	</object>
+	<object>
+		<name>BusinessProcess.ExecutionProcesses</name>
+		<right>
+			<name>InteractiveDelete</name>
 			<value>false</value>
 		</right>
 	</object>
@@ -2603,6 +2617,17 @@
 		</right>
 		<right>
 			<name>InteractiveDeleteMarkedPredefinedData</name>
+			<value>false</value>
+		</right>
+	</object>
+	<object>
+		<name>Catalog.ExecutionTemplates</name>
+		<right>
+			<name>InteractiveDelete</name>
+			<value>false</value>
+		</right>
+		<right>
+			<name>InteractiveDeletePredefinedData</name>
 			<value>false</value>
 		</right>
 	</object>


### PR DESCRIPTION
Added restrictions for 'InteractiveDelete' and 'InteractiveDeletePredefinedData' rights on Task.ExecutorTasks, BusinessProcess.ExecutionProcesses, and Catalog.ExecutionTemplates objects in both FullAccess and FullAccessNoAdminFunctions roles. This enhances security by preventing deletion actions for these objects.