### PR TITLE
Add support for PaymentInFiscalPrinterMode flag

### DIFF
--- a/IRP/src/CommonModules/EquipmentFiscalPrinterAPIClientServer/Module.bsl
+++ b/IRP/src/CommonModules/EquipmentFiscalPrinterAPIClientServer/Module.bsl
@@ -939,6 +939,7 @@ Function CheckPackage() Export
     Str.Payments.Insert("PrePayment", 0);
     Str.Payments.Insert("PostPayment", 0);
     Str.Payments.Insert("Barter", 0);
+	Str.Payments.Insert("PaymentsInFiscalPrinterMode", New Array);
     Return Str;
 EndFunction
 

--- a/IRP/src/CommonModules/EquipmentFiscalPrinterServer/Module.bsl
+++ b/IRP/src/CommonModules/EquipmentFiscalPrinterServer/Module.bsl
@@ -545,6 +545,10 @@ Procedure FillCheckPackageByRetailReceipt(Val SourceData, CheckPackage) Export
 			CheckPackage.Parameters.OperationType = 1;
 		Else
 			CheckPackage.Parameters.OperationType = 2;
+			If SourceData.ItemList.Count() Then
+				FiscalStatus = InformationRegisters.DocumentFiscalStatus.GetStatusData(SourceData.ItemList[0].RetailSalesReceipt);
+				CheckPackage.Parameters.CorrectionData.Insert("FiscalResponse", FiscalStatus.FiscalResponse); 
+			EndIf;
 		EndIf;		
 	EndIf;
 
@@ -1041,6 +1045,11 @@ Procedure FillPayments(SourceData, CheckPackage)
 		If Payment.Amount < 0 Then
 			Continue;
 		EndIf;
+		
+		If Payment.PaymentInFiscalPrinterMode Then
+			CheckPackage.Payments.PaymentsInFiscalPrinterMode.Add(Payment.Amount);
+			Continue;
+		EndIf;
 
 		If SourceData.PaymentMethod = Enums.ReceiptPaymentMethods.FullPrepayment Then
 			CheckPackage.Payments.PrePayment = CheckPackage.Payments.PrePayment + Payment.Amount;
@@ -1052,11 +1061,7 @@ Procedure FillPayments(SourceData, CheckPackage)
 			If Payment.PaymentType.Type = Enums.PaymentTypes.Cash Then
 				CheckPackage.Payments.Cash = CheckPackage.Payments.Cash + Payment.Amount;
 			ElsIf Payment.PaymentType.Type = Enums.PaymentTypes.Card Then
-				If Payment.PaymentInFiscalPrinterMode Then
-					CheckPackage.Payments.PostPayment = CheckPackage.Payments.PostPayment + Payment.Amount;
-				Else
-					CheckPackage.Payments.ElectronicPayment = CheckPackage.Payments.ElectronicPayment + Payment.Amount;
-				EndIf;
+				CheckPackage.Payments.ElectronicPayment = CheckPackage.Payments.ElectronicPayment + Payment.Amount;
 			ElsIf Payment.PaymentType.Type = Enums.PaymentTypes.PaymentAgent Then
 				CheckPackage.Payments.PostPayment = CheckPackage.Payments.PostPayment + Payment.Amount;
 			ElsIf Payment.PaymentType.Type = Enums.PaymentTypes.Advance Then
@@ -1070,11 +1075,7 @@ Procedure FillPayments(SourceData, CheckPackage)
 			If Payment.PaymentType.Type = Enums.PaymentTypes.Cash Then
 				CheckPackage.Payments.Cash = CheckPackage.Payments.Cash + Payment.Amount;
 			ElsIf Payment.PaymentType.Type = Enums.PaymentTypes.Card Then
-				If Payment.PaymentInFiscalPrinterMode Then
-					CheckPackage.Payments.PostPayment = CheckPackage.Payments.PostPayment + Payment.Amount;
-				Else
-					CheckPackage.Payments.ElectronicPayment = CheckPackage.Payments.ElectronicPayment + Payment.Amount;
-				EndIf;
+				CheckPackage.Payments.ElectronicPayment = CheckPackage.Payments.ElectronicPayment + Payment.Amount;
 			ElsIf Payment.PaymentType.Type = Enums.PaymentTypes.PaymentAgent Then
 				CheckPackage.Payments.PostPayment = CheckPackage.Payments.PostPayment + Payment.Amount;
 			ElsIf Payment.PaymentType.Type = Enums.PaymentTypes.Advance Then

--- a/IRP/src/CommonModules/RowIDInfoServer/Module.bsl
+++ b/IRP/src/CommonModules/RowIDInfoServer/Module.bsl
@@ -6088,6 +6088,7 @@ Function ExtractData_FromRSR(BasisesTable, DataReceiver, AddInfo = Undefined)
 	|	Payments.BankTerm,
 	|	Payments.Key,
 	|	Payments.Certificate,
+	|	Payments.PaymentInFiscalPrinterMode,
 	|	CAST("""" AS String(30)) AS RRNCode,
 	|	CAST("""" AS String(1024)) AS PaymentInfo
 	|FROM
@@ -6104,6 +6105,7 @@ Function ExtractData_FromRSR(BasisesTable, DataReceiver, AddInfo = Undefined)
 	|	Payments.PaymentTerminal,
 	|	Payments.PaymentType,
 	|	Payments.Certificate,
+	|	Payments.PaymentInFiscalPrinterMode,
 	|	Payments.Percent
 	|;
 	|
@@ -13854,7 +13856,11 @@ EndFunction
 #Region EmptyTables_Payments
 
 Function GetColumnNames_Payments()
-	Return "Key, Ref, PaymentType, PaymentTerminal, Account, FinancialMovementType, Percent, BankTerm, RRNCode, PaymentInfo, Certificate";
+	Return 
+		"Key, Ref, PaymentType, PaymentTerminal, 
+		|Account, FinancialMovementType, Percent, 
+		|BankTerm, RRNCode, PaymentInfo, 
+		|Certificate, PaymentInFiscalPrinterMode";
 EndFunction
 
 Function GetColumnNamesSum_Payments()

--- a/IRP/src/DataProcessors/PointOfSale/Forms/Form/Form.form
+++ b/IRP/src/DataProcessors/PointOfSale/Forms/Form/Form.form
@@ -1307,7 +1307,6 @@
                       <name>ItemListOnChange</name>
                     </handlers>
                     <searchStringAddition>
-                      <enabled>false</enabled>
                       <name>ItemListSearchString</name>
                       <id>610</id>
                       <extendedTooltip>
@@ -1331,7 +1330,6 @@
                       </extInfo>
                     </searchStringAddition>
                     <viewStatusAddition>
-                      <enabled>false</enabled>
                       <name>ItemListViewStatus</name>
                       <id>613</id>
                       <extendedTooltip>
@@ -1357,7 +1355,6 @@
                       </extInfo>
                     </viewStatusAddition>
                     <searchControlAddition>
-                      <enabled>false</enabled>
                       <name>ItemListSearchControl</name>
                       <id>616</id>
                       <extendedTooltip>
@@ -1653,7 +1650,6 @@
               <name>HTMLDate</name>
               <id>956</id>
               <visible>true</visible>
-              <enabled>false</enabled>
               <userVisible>
                 <common>true</common>
               </userVisible>
@@ -2975,7 +2971,6 @@
                   <horizontalAlign>Left</horizontalAlign>
                 </autoCommandBar>
                 <searchStringAddition>
-                  <enabled>false</enabled>
                   <name>BasisPaymentsSearchString</name>
                   <id>1186</id>
                   <extendedTooltip>
@@ -2999,7 +2994,6 @@
                   </extInfo>
                 </searchStringAddition>
                 <viewStatusAddition>
-                  <enabled>false</enabled>
                   <name>BasisPaymentsViewStatus</name>
                   <id>1192</id>
                   <extendedTooltip>
@@ -3024,7 +3018,6 @@
                   </extInfo>
                 </viewStatusAddition>
                 <searchControlAddition>
-                  <enabled>false</enabled>
                   <name>BasisPaymentsSearchControl</name>
                   <id>1189</id>
                   <extendedTooltip>
@@ -3266,7 +3259,6 @@
                   <name>ItemsPickupOnActivateRow</name>
                 </handlers>
                 <searchStringAddition>
-                  <enabled>false</enabled>
                   <name>ItemsPickupSearchString</name>
                   <id>669</id>
                   <extendedTooltip>
@@ -3297,7 +3289,6 @@
                   </extInfo>
                 </searchStringAddition>
                 <viewStatusAddition>
-                  <enabled>false</enabled>
                   <name>ItemsPickupViewStatus</name>
                   <id>672</id>
                   <extendedTooltip>
@@ -3323,7 +3314,6 @@
                   </extInfo>
                 </viewStatusAddition>
                 <searchControlAddition>
-                  <enabled>false</enabled>
                   <name>ItemsPickupSearchControl</name>
                   <id>675</id>
                   <extendedTooltip>
@@ -4121,7 +4111,6 @@
                   <autoFill>true</autoFill>
                 </autoCommandBar>
                 <searchStringAddition>
-                  <enabled>false</enabled>
                   <name>SpecialOffersSearchString</name>
                   <id>1281</id>
                   <extendedTooltip>
@@ -4145,7 +4134,6 @@
                   </extInfo>
                 </searchStringAddition>
                 <viewStatusAddition>
-                  <enabled>false</enabled>
                   <name>SpecialOffersViewStatus</name>
                   <id>1287</id>
                   <extendedTooltip>
@@ -4170,7 +4158,6 @@
                   </extInfo>
                 </viewStatusAddition>
                 <searchControlAddition>
-                  <enabled>false</enabled>
                   <name>SpecialOffersSearchControl</name>
                   <id>1284</id>
                   <extendedTooltip>
@@ -4894,7 +4881,6 @@
         <name>WorkstationCashAccount</name>
         <id>1167</id>
         <visible>true</visible>
-        <enabled>false</enabled>
         <userVisible>
           <common>true</common>
         </userVisible>
@@ -5151,7 +5137,6 @@
           <name>CashInListSelection</name>
         </handlers>
         <searchStringAddition>
-          <enabled>false</enabled>
           <name>CashInListSearchString</name>
           <id>1095</id>
           <extendedTooltip>
@@ -5175,7 +5160,6 @@
           </extInfo>
         </searchStringAddition>
         <viewStatusAddition>
-          <enabled>false</enabled>
           <name>CashInListViewStatus</name>
           <id>1101</id>
           <extendedTooltip>
@@ -5200,7 +5184,6 @@
           </extInfo>
         </viewStatusAddition>
         <searchControlAddition>
-          <enabled>false</enabled>
           <name>CashInListSearchControl</name>
           <id>1098</id>
           <extendedTooltip>

--- a/IRP/src/DataProcessors/PointOfSale/Forms/Form/Module.bsl
+++ b/IRP/src/DataProcessors/PointOfSale/Forms/Form/Module.bsl
@@ -2032,6 +2032,9 @@ Function CreateReturnOnBase(PaymentData, StatusType)
 		ExtractedDataItem.Payments.Clear();
 		ExtractedDataItem.SerialLotNumbers.Clear();
 		ExtractedDataItem.ControlCodeStrings.Clear();
+		If ExtractedDataItem.Payments.Columns.Find("PaymentInFiscalPrinterMode") = Undefined Then
+			ExtractedDataItem.Payments.Columns.Add("PaymentInFiscalPrinterMode", New TypeDescription("Boolean"));
+		EndIf;
 		If isFirst Then
 			isFirst = False;
 			For Each PaymentDataItem In PaymentData Do


### PR DESCRIPTION
Introduces the PaymentInFiscalPrinterMode property to payment data structures and processing logic. Updates modules to handle payments in fiscal printer mode, adjusts extraction and form logic, and ensures correct handling in payment processing and UI.