### PR TITLE
#IRP-765 При изменении Stock quantity не должен срабатывать пересчет на сумму

### DIFF
--- a/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
+++ b/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
@@ -12873,7 +12873,7 @@ EndFunction
 // ItemList.Quantity.Bind
 Function BindItemListQuantity(Parameters)
 	DataBinding = GetBindingStructure_ItemListQuantity(Parameters);		
-	Return BindSteps("BindVoid", 
+	Return BindSteps("StepItemListCalculateQuantityInBaseUnit", 
 		DataBinding.DataPath, 
 		DataBinding.Binding, 
 		Parameters, 

--- a/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
+++ b/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
@@ -14100,11 +14100,15 @@ Procedure StepItemListCalculations(Parameters, Chain, WhoIsChanged)
 		Options.Unit    = GetItemListUnit(Parameters, Row.Key);
 		
 		// need recalculate NetAmount, TotalAmount, TaxAmount, OffersAmount
-		If     WhoIsChanged = "IsPriceChanged"            Or WhoIsChanged = "IsPriceIncludeTaxChanged"
-			Or WhoIsChanged = "IsDontCalculateRowChanged" Or WhoIsChanged = "IsQuantityInBaseUnitChanged" 
-			Or WhoIsChanged = "IsVatRateChanged"          Or WhoIsChanged = "IsOffersChanged"
-			Or WhoIsChanged = "IsCopyRow"                 Or WhoIsChanged = "IsTaxAmountUserFormChanged"
-			Or WhoIsChanged = "RecalculationsOnCopy"      Or WhoIsChanged = "IsRecalculationWhenBasedOn" Then
+		If     WhoIsChanged = "IsPriceChanged"            
+			Or WhoIsChanged = "IsPriceIncludeTaxChanged"
+			Or WhoIsChanged = "IsDontCalculateRowChanged"  
+			Or WhoIsChanged = "IsVatRateChanged"          
+			Or WhoIsChanged = "IsOffersChanged"
+			Or WhoIsChanged = "IsCopyRow"                 
+			Or WhoIsChanged = "IsTaxAmountUserFormChanged"
+			Or WhoIsChanged = "RecalculationsOnCopy"      
+			Or WhoIsChanged = "IsRecalculationWhenBasedOn" Then
 			Options.CalculateNetAmount.Enable       = True;
 			Options.CalculateTotalAmount.Enable     = True;
 			Options.CalculateTaxAmount.Enable       = True;
@@ -14182,7 +14186,6 @@ Procedure StepItemListCalculations_Without_SpecialOffers(Parameters, Chain, WhoI
 		If     WhoIsChanged = "IsPriceChanged"            
 		    Or WhoIsChanged = "IsPriceIncludeTaxChanged"
 			Or WhoIsChanged = "IsDontCalculateRowChanged" 
-			Or WhoIsChanged = "IsQuantityInBaseUnitChanged" 
 			Or WhoIsChanged = "IsVatRateChanged"
 		    Or WhoIsChanged = "IsTaxAmountUserFormChanged"
 			Or WhoIsChanged = "IsRecalculationWhenBasedOn" Then
@@ -14251,7 +14254,6 @@ Procedure StepItemListCalculations_StockDocuments(Parameters, Chain, WhoIsChange
 		
 		// need recalculate NetAmount, TotalAmount, TaxAmount
 		If 	   WhoIsChanged = "IsPriceChanged"
-			Or WhoIsChanged = "IsQuantityInBaseUnitChanged" 
 			Or WhoIsChanged = "IsVatRateChanged"   
 			Or WhoIsChanged = "IsRecalculationWhenBasedOn" Then
 			Options.CalculateNetAmount.Enable     = True;

--- a/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
+++ b/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
@@ -13891,6 +13891,8 @@ Procedure SetItemListCalculations_Without_SpecialOffers(Parameters, Results) Exp
 	ViewNotify = "OnSetCalculationsNotify";
 	NotifyAnyway = True;
 	Binding = BindItemListCalculations(Parameters);
+	SetterObject(Undefined, "ItemList.Quantity"    , Parameters, Results, ViewNotify, "Quantity"     , NotifyAnyway);
+	SetterObject(Undefined, "ItemList.QuantityInBaseUnit", Parameters, Results, ViewNotify, "QuantityInBaseUnit", NotifyAnyway);
 	SetterObject(Undefined, "ItemList.NetAmount"   , Parameters, Results, ViewNotify, "NetAmount"    , NotifyAnyway);
 	SetterObject(Undefined, "ItemList.TaxAmount"   , Parameters, Results, ViewNotify, "TaxAmount"    , NotifyAnyway);
 	SetterObject(Undefined, "ItemList.Price"       , Parameters, Results, ViewNotify, "Price"        , NotifyAnyway);
@@ -13903,6 +13905,8 @@ Procedure SetItemListCalculations_StockDocuments(Parameters, Results) Export
 	ViewNotify = "OnSetCalculationsNotify";
 	NotifyAnyway = True;
 	Binding = BindItemListCalculations(Parameters);
+	SetterObject(Undefined, "ItemList.Quantity"    , Parameters, Results, ViewNotify, "Quantity"   , NotifyAnyway);
+	SetterObject(Undefined, "ItemList.QuantityInBaseUnit", Parameters, Results, ViewNotify, "QuantityInBaseUnit", NotifyAnyway);
 	SetterObject(Undefined, "ItemList.NetAmount"   , Parameters, Results, ViewNotify, "NetAmount"  , NotifyAnyway);
 	SetterObject(Undefined, "ItemList.TaxAmount"   , Parameters, Results, ViewNotify, "TaxAmount"  , NotifyAnyway);
 	SetterObject(Undefined, "ItemList.Price"       , Parameters, Results, ViewNotify, "Price"      , NotifyAnyway);
@@ -14242,6 +14246,8 @@ Procedure StepItemListCalculations(Parameters, Chain, WhoIsChanged)
 			Options.CalculateNetAmount.Enable = True;
 			Options.CalculateTotalAmount.Enable = True;
 			Options.CalculateTaxAmount.Enable = True;
+			Options.CalculateSpecialOffers.Enable   = True;
+			Options.RecalculateSpecialOffers.Enable = True;
 			Options.CalculateQuantityInBaseUnit.Enable = True;			
 		Else
 			Raise StrTemplate(R().UnsupportedWhoIsChanged, WhoIsChanged);

--- a/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
+++ b/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
@@ -14132,6 +14132,8 @@ Procedure StepItemListCalculations(Parameters, Chain, WhoIsChanged)
 			Options.CalculateNetAmount.Enable   = True;
 			Options.CalculateTotalAmount.Enable = True;
 			Options.CalculateTaxAmount.Enable   = True;
+		ElsIf WhoIsChanged = "IsQuantityInBaseUnitChanged" Then
+			// nothing to do
 		Else
 			Raise StrTemplate(R().UnsupportedWhoIsChanged, WhoIsChanged);
 		EndIf;
@@ -14210,6 +14212,8 @@ Procedure StepItemListCalculations_Without_SpecialOffers(Parameters, Chain, WhoI
 			Options.CalculateNetAmount.Enable   = True;
 			Options.CalculateTotalAmount.Enable = True;
 			Options.CalculateTaxAmount.Enable   = True;
+		ElsIf WhoIsChanged = "IsQuantityInBaseUnitChanged" Then
+			// nothing to do
 		Else
 			Raise StrTemplate(R().UnsupportedWhoIsChanged, WhoIsChanged);
 		EndIf;
@@ -14270,6 +14274,8 @@ Procedure StepItemListCalculations_StockDocuments(Parameters, Chain, WhoIsChange
 			Options.CalculateNetAmount.Enable   = True;
 			Options.CalculateTotalAmount.Enable = True;
 			Options.CalculateTaxAmount.Enable   = True;
+		ElsIf WhoIsChanged = "IsQuantityInBaseUnitChanged" Then
+			// nothing to do
 		Else
 			Raise StrTemplate(R().UnsupportedWhoIsChanged, WhoIsChanged);
 		EndIf;

--- a/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
+++ b/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
@@ -12873,7 +12873,7 @@ EndFunction
 // ItemList.Quantity.Bind
 Function BindItemListQuantity(Parameters)
 	DataBinding = GetBindingStructure_ItemListQuantity(Parameters);		
-	Return BindSteps("StepItemListCalculateQuantityInBaseUnit", 
+	Return BindSteps("BindVoid", 
 		DataBinding.DataPath, 
 		DataBinding.Binding, 
 		Parameters, 
@@ -13876,6 +13876,8 @@ Procedure SetItemListCalculations(Parameters, Results) Export
 	ViewNotify = "OnSetCalculationsNotify";
 	NotifyAnyway = True;
 	Binding = BindItemListCalculations(Parameters);
+	SetterObject(Undefined, "ItemList.Quantity"    , Parameters, Results, ViewNotify, "Quantity"     , NotifyAnyway);
+	SetterObject(Undefined, "ItemList.QuantityInBaseUnit", Parameters, Results, ViewNotify, "QuantityInBaseUnit", NotifyAnyway);
 	SetterObject(Undefined, "ItemList.NetAmount"   , Parameters, Results, ViewNotify, "NetAmount"    , NotifyAnyway);
 	SetterObject(Undefined, "ItemList.TaxAmount"   , Parameters, Results, ViewNotify, "TaxAmount"    , NotifyAnyway);
 	SetterObject(Undefined, "ItemList.OffersAmount", Parameters, Results, ViewNotify, "OffersAmount" , NotifyAnyway);
@@ -14195,6 +14197,12 @@ Procedure StepItemListCalculations(Parameters, Chain, WhoIsChanged)
 		Options.ItemKey = GetItemListItemKey(Parameters, Row.Key);
 		Options.Unit    = GetItemListUnit(Parameters, Row.Key);
 		
+		Options.QuantityOptions.ItemKey            = GetItemListItemKey(Parameters, Row.Key);
+		Options.QuantityOptions.Unit               = GetItemListUnit(Parameters, Row.Key);
+		Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
+		Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
+		Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
+		
 		// need recalculate NetAmount, TotalAmount, TaxAmount, OffersAmount
 		If     WhoIsChanged = "IsPriceChanged"            
 			Or WhoIsChanged = "IsPriceIncludeTaxChanged"
@@ -14230,17 +14238,11 @@ Procedure StepItemListCalculations(Parameters, Chain, WhoIsChanged)
 			Options.CalculateTaxAmount.Enable   = True;
 		ElsIf WhoIsChanged = "IsQuantityInBaseUnitChanged" Then
 			Options.CalculateQuantity.Enable = True;			
-			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
 		ElsIf WhoIsChanged = "IsQuantityChanged" Then
 			Options.CalculateNetAmount.Enable = True;
 			Options.CalculateTotalAmount.Enable = True;
 			Options.CalculateTaxAmount.Enable = True;
 			Options.CalculateQuantityInBaseUnit.Enable = True;			
-			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
 		Else
 			Raise StrTemplate(R().UnsupportedWhoIsChanged, WhoIsChanged);
 		EndIf;
@@ -14291,6 +14293,12 @@ Procedure StepItemListCalculations_Without_SpecialOffers(Parameters, Chain, WhoI
 		Options     = ModelClientServer_V2.CalculationsOptions();
 		Options.Ref = Parameters.Object.Ref;
 		
+		Options.QuantityOptions.ItemKey            = GetItemListItemKey(Parameters, Row.Key);
+		Options.QuantityOptions.Unit               = GetItemListUnit(Parameters, Row.Key);
+		Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
+		Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
+		Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
+		
 		// need recalculate NetAmount, TotalAmount, TaxAmount
 		If     WhoIsChanged = "IsPriceChanged"            
 		    Or WhoIsChanged = "IsPriceIncludeTaxChanged"
@@ -14321,17 +14329,11 @@ Procedure StepItemListCalculations_Without_SpecialOffers(Parameters, Chain, WhoI
 			Options.CalculateTaxAmount.Enable   = True;
 		ElsIf WhoIsChanged = "IsQuantityInBaseUnitChanged" Then
 			Options.CalculateQuantity.Enable = True;			
-			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
 		ElsIf WhoIsChanged = "IsQuantityChanged" Then
 			Options.CalculateNetAmount.Enable = True;
 			Options.CalculateTotalAmount.Enable = True;
 			Options.CalculateTaxAmount.Enable = True;
 			Options.CalculateQuantityInBaseUnit.Enable = True;			
-			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
 		Else
 			Raise StrTemplate(R().UnsupportedWhoIsChanged, WhoIsChanged);
 		EndIf;
@@ -14374,6 +14376,12 @@ Procedure StepItemListCalculations_StockDocuments(Parameters, Chain, WhoIsChange
 		Options     = ModelClientServer_V2.CalculationsOptions();
 		Options.Ref = Parameters.Object.Ref;
 		
+		Options.QuantityOptions.ItemKey            = GetItemListItemKey(Parameters, Row.Key);
+		Options.QuantityOptions.Unit               = GetItemListUnit(Parameters, Row.Key);
+		Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
+		Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
+		Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
+		
 		// need recalculate NetAmount, TotalAmount, TaxAmount
 		If 	   WhoIsChanged = "IsPriceChanged"
 			Or WhoIsChanged = "IsVatRateChanged"   
@@ -14394,17 +14402,11 @@ Procedure StepItemListCalculations_StockDocuments(Parameters, Chain, WhoIsChange
 			Options.CalculateTaxAmount.Enable   = True;
 		ElsIf WhoIsChanged = "IsQuantityInBaseUnitChanged" Then
 			Options.CalculateQuantity.Enable = True;			
-			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
 		ElsIf WhoIsChanged = "IsQuantityChanged" Then
 			Options.CalculateNetAmount.Enable = True;
 			Options.CalculateTotalAmount.Enable = True;
 			Options.CalculateTaxAmount.Enable = True;
 			Options.CalculateQuantityInBaseUnit.Enable = True;			
-			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
-			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
 		Else
 			Raise StrTemplate(R().UnsupportedWhoIsChanged, WhoIsChanged);
 		EndIf;

--- a/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
+++ b/IRP/src/CommonModules/ControllerClientServer_V2/Module.bsl
@@ -12812,8 +12812,61 @@ Function BindDefaultItemListQuantity(Parameters)
 EndFunction
 
 Function GetBindingStructure_ItemListQuantity(Parameters)
-	Result = New Structure("Binding, DataPath, ExtensionPrefix", New Structure(), Undefined, "");
-	Result.DataPath = "ItemList.Quantity";
+	
+	Binding = New Structure();
+	Binding.Insert("SalesOrder",
+		"StepItemListCalculations_IsQuantityChanged");
+	
+	Binding.Insert("WorkOrder", 
+		"StepItemListCalculations_IsQuantityChanged,
+		|StepMaterialsRecalculateQuantityWithKeyOwner");
+	
+	Binding.Insert("WorkSheet", 
+		"StepMaterialsRecalculateQuantityWithKeyOwner");
+		
+	Binding.Insert("SalesInvoice",
+		"StepItemListCalculations_IsQuantityChanged");
+	
+	Binding.Insert("RetailSalesReceipt",
+		"StepItemListCalculations_IsQuantityChanged");
+	
+	Binding.Insert("RetailReceiptCorrection",
+		"StepItemListCalculations_IsQuantityChanged");
+	
+	Binding.Insert("PurchaseOrder",
+		"StepItemListCalculations_IsQuantityChanged");
+	
+	Binding.Insert("PurchaseInvoice",
+		"StepItemListCalculations_IsQuantityChanged");
+	
+	Binding.Insert("WithholdingTaxInvoice",
+		"StepItemListCalculations_IsQuantityChanged_Withholding_Tax");
+	
+	Binding.Insert("SalesReportFromTradeAgent",
+		"StepItemListCalculations_IsQuantityChanged_Without_SpecialOffers");
+	
+	Binding.Insert("SalesReportToConsignor",
+		"StepItemListCalculations_IsQuantityChanged_Without_SpecialOffers");
+	
+	Binding.Insert("RetailReturnReceipt",
+		"StepItemListCalculations_IsQuantityChanged");
+	
+	Binding.Insert("PurchaseReturnOrder",
+		"StepItemListCalculations_IsQuantityChanged");
+	
+	Binding.Insert("PurchaseReturn",
+		"StepItemListCalculations_IsQuantityChanged");
+	
+	Binding.Insert("SalesReturnOrder",
+		"StepItemListCalculations_IsQuantityChanged");
+	
+	Binding.Insert("SalesReturn",
+		"StepItemListCalculations_IsQuantityChanged");
+			
+	Binding.Insert("StockAdjustmentAsSurplus",
+		"StepItemListCalculations_IsQuantityChanged_StockDocuments");
+	
+	Result = New Structure("Binding, DataPath, ExtensionPrefix", Binding, "ItemList.Quantity", "");
 	Return Result;
 EndFunction
 
@@ -12840,6 +12893,29 @@ Procedure StepItemListDefaultQuantityInList(Parameters, Chain) Export
 	Options.CurrentQuantity = GetItemListQuantity(Parameters, NewRow.Key);
 	Options.Key = NewRow.Key;
 	Chain.DefaultQuantityInList.Options.Add(Options);
+EndProcedure
+
+// ItemList.Quantity.CalculateQuantity.Step
+Procedure StepItemListCalculateQuantity(Parameters, Chain) Export
+	StepName = "StepItemListCalculateQuantity";
+	Chain.Calculations.Enable = True;
+	If Chain.Idle Then
+		Return;
+	EndIf;
+	Chain.Calculations.Setter = "SetItemListQuantity";
+	For Each Row In GetRows(Parameters, "ItemList") Do
+		Options     = ModelClientServer_V2.CalculationsOptions();
+		Options.Ref = Parameters.Object.Ref;
+		Options.CalculateQuantity.Enable = True;
+		Options.QuantityOptions.ItemKey = GetItemListItemKey(Parameters, Row.Key);
+		Options.QuantityOptions.Unit    = GetItemListUnit(Parameters, Row.Key);
+		Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
+		Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
+		Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
+		Options.Key = Row.Key;
+		Options.StepName = StepName;
+		Chain.Calculations.Options.Add(Options);
+	EndDo;	
 EndProcedure
 
 #EndRegion
@@ -13858,6 +13934,11 @@ EndFunction
 
 #Region ITEM_LIST_CALCULATIONS_WITHHOLDING_TAX
 
+// ItemList.Calculations.[IsQuantityChanged_Withholding_Tax].Step
+Procedure StepItemListCalculations_IsQuantityChanged_Withholding_Tax(Parameters, Chain) Export
+	StepItemListCalculations_Withholding_Tax(Parameters, Chain, "IsQuantityChanged");
+EndProcedure
+
 // ItemList.Calculations.[IsQuantityInBaseUnitChanged_Withholding_Tax].Step
 Procedure StepItemListCalculations_IsQuantityInBaseUnitChanged_Withholding_Tax(Parameters, Chain) Export
 	StepItemListCalculations_Withholding_Tax(Parameters, Chain, "IsQuantityInBaseUnitChanged");
@@ -13960,6 +14041,11 @@ Procedure StepItemListCalculations_IsDontCalculateRowChanged_Without_SpecialOffe
 	StepItemListCalculations_Without_SpecialOffers(Parameters, Chain, "IsDontCalculateRowChanged");
 EndProcedure
 
+// ItemList.Calculations.[IsQuantityChanged_Without_SpecialOffers].Step
+Procedure StepItemListCalculations_IsQuantityChanged_Without_SpecialOffers(Parameters, Chain) Export
+	StepItemListCalculations_Without_SpecialOffers(Parameters, Chain, "IsQuantityChanged");
+EndProcedure
+
 // ItemList.Calculations.[IsQuantityInBaseUnitChanged_Without_SpecialOffers].Step
 Procedure StepItemListCalculations_IsQuantityInBaseUnitChanged_Without_SpecialOffers(Parameters, Chain) Export
 	StepItemListCalculations_Without_SpecialOffers(Parameters, Chain, "IsQuantityInBaseUnitChanged");
@@ -14021,6 +14107,11 @@ Procedure StepItemListCalculations_IsDontCalculateRowChanged(Parameters, Chain) 
 	StepItemListCalculations(Parameters, Chain, "IsDontCalculateRowChanged");
 EndProcedure
 
+// ItemList.Calculations.[IsQuantityChanged].Step
+Procedure StepItemListCalculations_IsQuantityChanged(Parameters, Chain) Export
+	StepItemListCalculations(Parameters, Chain, "IsQuantityChanged");
+EndProcedure
+
 // ItemList.Calculations.[IsQuantityInBaseUnitChanged].Step
 Procedure StepItemListCalculations_IsQuantityInBaseUnitChanged(Parameters, Chain) Export
 	StepItemListCalculations(Parameters, Chain, "IsQuantityInBaseUnitChanged");
@@ -14058,6 +14149,11 @@ EndProcedure
 // ItemList.Calculations.[IsTotalAmountChanged_StockDocuments].Step
 Procedure StepItemListCalculations_IsTotalAmountChanged_StockDocuments(Parameters, Chain) Export
 	StepItemListCalculations_StockDocuments(Parameters, Chain, "IsTotalAmountChanged");
+EndProcedure
+
+// ItemList.Calculations.[IsQuantityChanged_StockDocuments].Step
+Procedure StepItemListCalculations_IsQuantityChanged_StockDocuments(Parameters, Chain) Export
+	StepItemListCalculations_StockDocuments(Parameters, Chain, "IsQuantityChanged");
 EndProcedure
 
 // ItemList.Calculations.[IsQuantityInBaseUnitChanged_StockDocuments].Step
@@ -14133,7 +14229,18 @@ Procedure StepItemListCalculations(Parameters, Chain, WhoIsChanged)
 			Options.CalculateTotalAmount.Enable = True;
 			Options.CalculateTaxAmount.Enable   = True;
 		ElsIf WhoIsChanged = "IsQuantityInBaseUnitChanged" Then
-			// nothing to do
+			Options.CalculateQuantity.Enable = True;			
+			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
+		ElsIf WhoIsChanged = "IsQuantityChanged" Then
+			Options.CalculateNetAmount.Enable = True;
+			Options.CalculateTotalAmount.Enable = True;
+			Options.CalculateTaxAmount.Enable = True;
+			Options.CalculateQuantityInBaseUnit.Enable = True;			
+			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
 		Else
 			Raise StrTemplate(R().UnsupportedWhoIsChanged, WhoIsChanged);
 		EndIf;
@@ -14213,7 +14320,18 @@ Procedure StepItemListCalculations_Without_SpecialOffers(Parameters, Chain, WhoI
 			Options.CalculateTotalAmount.Enable = True;
 			Options.CalculateTaxAmount.Enable   = True;
 		ElsIf WhoIsChanged = "IsQuantityInBaseUnitChanged" Then
-			// nothing to do
+			Options.CalculateQuantity.Enable = True;			
+			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
+		ElsIf WhoIsChanged = "IsQuantityChanged" Then
+			Options.CalculateNetAmount.Enable = True;
+			Options.CalculateTotalAmount.Enable = True;
+			Options.CalculateTaxAmount.Enable = True;
+			Options.CalculateQuantityInBaseUnit.Enable = True;			
+			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
 		Else
 			Raise StrTemplate(R().UnsupportedWhoIsChanged, WhoIsChanged);
 		EndIf;
@@ -14275,7 +14393,18 @@ Procedure StepItemListCalculations_StockDocuments(Parameters, Chain, WhoIsChange
 			Options.CalculateTotalAmount.Enable = True;
 			Options.CalculateTaxAmount.Enable   = True;
 		ElsIf WhoIsChanged = "IsQuantityInBaseUnitChanged" Then
-			// nothing to do
+			Options.CalculateQuantity.Enable = True;			
+			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
+		ElsIf WhoIsChanged = "IsQuantityChanged" Then
+			Options.CalculateNetAmount.Enable = True;
+			Options.CalculateTotalAmount.Enable = True;
+			Options.CalculateTaxAmount.Enable = True;
+			Options.CalculateQuantityInBaseUnit.Enable = True;			
+			Options.QuantityOptions.Quantity           = GetItemListQuantity(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityInBaseUnit = GetItemListQuantityInBaseUnit(Parameters, Row.Key);
+			Options.QuantityOptions.QuantityIsFixed    = GetItemListQuantityIsFixed(Parameters, Row.Key);
 		Else
 			Raise StrTemplate(R().UnsupportedWhoIsChanged, WhoIsChanged);
 		EndIf;

--- a/IRP/src/CommonModules/ModelClientServer_V2/Module.bsl
+++ b/IRP/src/CommonModules/ModelClientServer_V2/Module.bsl
@@ -3022,7 +3022,6 @@ Function CalculationsExecute(Options) Export
 				UnitFactor = GetItemInfo.GetUnitFactor(Options.QuantityOptions.ItemKey, Options.QuantityOptions.Unit);
 			EndIf;
 			Result.QuantityInBaseUnit = Options.QuantityOptions.Quantity * UnitFactor;
-			Options.QuantityOptions.QuantityInBaseUnit = Result.QuantityInBaseUnit; 
 			Options.PriceOptions.QuantityInBaseUnit = Result.QuantityInBaseUnit; 
 		ElsIf Options.CalculateQuantity.Enable Then
 			If Not ValueIsFilled(Options.QuantityOptions.ItemKey) Then
@@ -3031,7 +3030,6 @@ Function CalculationsExecute(Options) Export
 				UnitFactor = GetItemInfo.GetUnitFactor(Options.QuantityOptions.ItemKey, Options.QuantityOptions.Unit);
 			EndIf;
 			Result.Quantity = Options.QuantityOptions.QuantityInBaseUnit / UnitFactor;
-			Options.QuantityOptions.Quantity = Result.Quantity;
 			Options.PriceOptions.Quantity = Result.Quantity;
 		EndIf;
 	EndIf;

--- a/IRP/src/CommonModules/ModelClientServer_V2/Module.bsl
+++ b/IRP/src/CommonModules/ModelClientServer_V2/Module.bsl
@@ -2861,6 +2861,68 @@ EndFunction
 
 #Region CALCULATIONS
 
+// Calculations options.
+// 
+// Returns:
+//  Structure - Calculations options:
+// * Key - String -
+// * StepName - String -
+// * DontExecuteIfExecutedBefore - Boolean - 
+// * DisableNextSteps - Boolean - 
+// * AmountOptions - Structure - :
+// ** DontCalculateRow - Boolean - 
+// ** NetAmount - Number - 
+// ** OffersAmount - Number - 
+// ** OffersBonus - Number - 
+// ** TaxAmount - Number - 
+// ** TotalAmount - Number - 
+// * PriceOptions - Structure - :
+// ** PriceType - CatalogRef.PriceTypes -
+// ** Price - Number -
+// ** Quantity - Number -
+// ** QuantityInBaseUnit - Number -
+// * TaxOptions - Structure - :
+// ** PriceIncludeTax - Boolean -
+// ** VatRate - CatalogRef.TaxRates -
+// ** UseManualAmount - Boolean -
+// * QuantityOptions - Structure - :
+// ** ItemKey - CatalogRef.ItemKeys - 
+// ** Unit - CatalogRef.Units -
+// ** Quantity - Number - 
+// ** QuantityInBaseUnit - Number - 
+// ** QuantityIsFixed - Boolean - 
+// * OffersOptions - Structure - :
+// ** SpecialOffers - Array - 
+// ** SpecialOffersCache - Array - 
+// * CalculateTotalAmount - Structure - :
+// ** Enable - Boolean - 
+// * CalculateTotalAmountByNetAmount - Structure - :
+// ** Enable - Boolean - 
+// * CalculateNetAmount - Structure - :
+// ** Enable - Boolean - 
+// * CalculateNetAmountByTotalAmount - Structure - :
+// ** Enable - Boolean - 
+// * CalculateNetAmountAsTotalAmountMinusTaxAmount - Structure - :
+// ** Enable - Boolean - 
+// * CalculateTaxAmount - Structure - :
+// ** Enable - Boolean - 
+// * CalculateTaxAmountByNetAmount - Structure - :
+// ** Enable - Boolean - 
+// * CalculateTaxAmountByTotalAmount - Structure - :
+// ** Enable - Boolean - 
+// * CalculateTaxAmountReverse - Structure - :
+// ** Enable - Boolean - 
+// * CalculatePriceByTotalAmount - Structure - :
+// ** Enable - Boolean - 
+// * CalculateQuantityInBaseUnit - Structure - :
+// ** Enable - Boolean - 
+// * CalculateQuantity - Structure - :
+// ** Enable - Boolean - 
+// * CalculateSpecialOffers - Structure - :
+// ** Enable - Boolean - 
+// * RecalculateSpecialOffers - Structure - :
+// ** Enable - Boolean - 
+// * RowIDInfo - Array - 
 Function CalculationsOptions() Export
 	Options = GetChainLinkOptions("Ref, ItemKey, Unit");
 	
@@ -2908,6 +2970,7 @@ Function CalculationsOptions() Export
 	
 	// QuantityInBaseUnit
 	Options.Insert("CalculateQuantityInBaseUnit" , New Structure("Enable", False));
+	Options.Insert("CalculateQuantity" , New Structure("Enable", False));
 	
 	// SpecialOffers
 	Options.Insert("CalculateSpecialOffers"   , New Structure("Enable", False));
@@ -2918,6 +2981,23 @@ Function CalculationsOptions() Export
 	Return Options;
 EndFunction
 
+// Calculations execute.
+// 
+// Parameters:
+//  Options - See CalculationsOptions
+// 
+// Returns:
+//  Structure - Calculations execute:
+// * NetAmount - Number - 
+// * OffersAmount - Number - 
+// * OffersBonus - Number - 
+// * TaxAmount - Number - 
+// * TotalAmount - Number - 
+// * Price - Number - 
+// * Quantity - Number - 
+// * QuantityInBaseUnit - Number - 
+// * QuantityIsFixed - Boolean - 
+// * SpecialOffers - Array - 
 Function CalculationsExecute(Options) Export
 	IsCalculatedRow = Not Options.AmountOptions.DontCalculateRow;
 
@@ -2928,9 +3008,33 @@ Function CalculationsExecute(Options) Export
 	Result.Insert("TaxAmount"    , Options.AmountOptions.TaxAmount);
 	Result.Insert("TotalAmount"  , Options.AmountOptions.TotalAmount);
 	Result.Insert("Price"        , Options.PriceOptions.Price);
+	Result.Insert("Quantity"     , Options.QuantityOptions.Quantity);
 	Result.Insert("QuantityInBaseUnit" , Options.QuantityOptions.QuantityInBaseUnit);
 	Result.Insert("QuantityIsFixed"    , Options.QuantityOptions.QuantityIsFixed);
 	Result.Insert("SpecialOffers", New Array());
+	
+	// Calculate Quantity
+	If Options.QuantityOptions.QuantityIsFixed <> True Then
+		If Options.CalculateQuantityInBaseUnit.Enable Then
+			If Not ValueIsFilled(Options.QuantityOptions.ItemKey) Then
+				UnitFactor = 0;
+			Else
+				UnitFactor = GetItemInfo.GetUnitFactor(Options.QuantityOptions.ItemKey, Options.QuantityOptions.Unit);
+			EndIf;
+			Result.QuantityInBaseUnit = Options.QuantityOptions.Quantity * UnitFactor;
+			Options.QuantityOptions.QuantityInBaseUnit = Result.QuantityInBaseUnit; 
+			Options.PriceOptions.QuantityInBaseUnit = Result.QuantityInBaseUnit; 
+		ElsIf Options.CalculateQuantity.Enable Then
+			If Not ValueIsFilled(Options.QuantityOptions.ItemKey) Then
+				UnitFactor = 1;
+			Else
+				UnitFactor = GetItemInfo.GetUnitFactor(Options.QuantityOptions.ItemKey, Options.QuantityOptions.Unit);
+			EndIf;
+			Result.Quantity = Options.QuantityOptions.QuantityInBaseUnit / UnitFactor;
+			Options.QuantityOptions.Quantity = Result.Quantity;
+			Options.PriceOptions.Quantity = Result.Quantity;
+		EndIf;
+	EndIf;
 	
 	For Each OfferRow In Options.OffersOptions.SpecialOffers Do
 		NewOfferRow = OffersServer.GetOffersTableRow();
@@ -3003,16 +3107,6 @@ Function CalculationsExecute(Options) Export
 		EndDo;
 		Result.OffersAmount = TotalOffers;
 		Result.OffersBonus = TotalBonus;
-	EndIf;
-	
-	// CalculateQuantityInBaseUnit
-	If Options.CalculateQuantityInBaseUnit.Enable And (Options.QuantityOptions.QuantityIsFixed <> True) Then
-		If Not ValueIsFilled(Options.QuantityOptions.ItemKey) Then
-			UnitFactor = 0;
-		Else
-			UnitFactor = GetItemInfo.GetUnitFactor(Options.QuantityOptions.ItemKey, Options.QuantityOptions.Unit);
-		EndIf;
-		Result.QuantityInBaseUnit = Options.QuantityOptions.Quantity * UnitFactor;
 	EndIf;
 	
 	If Options.TaxOptions.PriceIncludeTax <> Undefined Then

--- a/IRP/src/CommonModules/ModelClientServer_V2/Module.bsl
+++ b/IRP/src/CommonModules/ModelClientServer_V2/Module.bsl
@@ -3017,7 +3017,7 @@ Function CalculationsExecute(Options) Export
 	If Options.QuantityOptions.QuantityIsFixed <> True Then
 		If Options.CalculateQuantityInBaseUnit.Enable Then
 			If Not ValueIsFilled(Options.QuantityOptions.ItemKey) Then
-				UnitFactor = 0;
+				UnitFactor = 1;
 			Else
 				UnitFactor = GetItemInfo.GetUnitFactor(Options.QuantityOptions.ItemKey, Options.QuantityOptions.Unit);
 			EndIf;

--- a/IRP/src/CommonModules/ViewClient_V2/Module.bsl
+++ b/IRP/src/CommonModules/ViewClient_V2/Module.bsl
@@ -2925,7 +2925,63 @@ Procedure SetItemListQuantity(Object, Form, Row, Value) Export
 EndProcedure
 
 Procedure OnSetItemListQuantityNotify(Parameters) Export
-	Return;
+	If Parameters.ObjectMetadataInfo.Tables.Property("SourceOfOrigins") Then
+		SourceOfOriginClient.UpdateSourceOfOriginsQuantity(Parameters.Object, Parameters.Form);
+	EndIf;
+	
+	// Update -> RowIDInfoQuantity
+	If Parameters.ObjectMetadataInfo.MetadataName = "SalesInvoice"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "PurchaseInvoice" 
+		Or Parameters.ObjectMetadataInfo.MetadataName = "ShipmentConfirmation" 
+		Or Parameters.ObjectMetadataInfo.MetadataName = "ShipmentPlaningOrder" 
+		Or Parameters.ObjectMetadataInfo.MetadataName = "RetailShipmentConfirmation" 
+		Or Parameters.ObjectMetadataInfo.MetadataName = "GoodsReceipt"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "RetailGoodsReceipt"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "StockAdjustmentAsSurplus"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "StockAdjustmentAsWriteOff"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "RetailSalesReceipt"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "RetailReceiptCorrection"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "RetailReturnReceipt"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "PurchaseReturn"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "SalesReturn"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "SalesOrder"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "WorkOrder"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "WorkSheet"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "SalesReturnOrder"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "PurchaseOrder"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "PurchaseReturnOrder"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "InventoryTransfer"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "InventoryTransferOrder" Then
+		
+		RowIDInfoClientServer.UpdateQuantity(Parameters.Object);
+	EndIf;
+	
+	If CommonFunctionsClientServer.ObjectHasProperty(Parameters.Object, "ShipmentConfirmations") Then
+		DocumentsClientServer.UpdateQuantityByTradeDocuments(Parameters.Object, "ShipmentConfirmations");
+	EndIf;
+	
+	If CommonFunctionsClientServer.ObjectHasProperty(Parameters.Object, "ShipmentPlaningOrders") Then
+		DocumentsClientServer.UpdateQuantityByTradeDocuments(Parameters.Object, "ShipmentPlaningOrders");
+	EndIf;
+	
+	If CommonFunctionsClientServer.ObjectHasProperty(Parameters.Object, "GoodsReceipts") Then
+		DocumentsClientServer.UpdateQuantityByTradeDocuments(Parameters.Object, "GoodsReceipts");
+	EndIf;
+	
+	If Parameters.ObjectMetadataInfo.MetadataName = "WorkOrder"
+		Or Parameters.ObjectMetadataInfo.MetadataName = "WorkSheet" Then
+		VisibleRows = Parameters.Object.Materials.FindRows(New Structure("IsVisible", True));
+		If VisibleRows.Count() Then
+			Parameters.Form.Items.Materials.CurrentRow = VisibleRows[0].GetID();
+		EndIf;
+	EndIf;
+	
+	If Parameters.ObjectMetadataInfo.Tables.Property("ControlCodeStrings") Then
+		If Not Parameters.isRowsAddByScan Then 
+			ControlCodeStringsClient.ClearAllByRow(Parameters.Object, Parameters.UpdatedRowsByScan);
+			ControlCodeStringsClient.UpdateState(Parameters.Object);
+		EndIf;
+	EndIf;
 EndProcedure
 
 #EndRegion


### PR DESCRIPTION
Removed 'IsQuantityInBaseUnitChanged' from the recalculation conditions in StepItemListCalculations_Without_SpecialOffers and StepItemListCalculations_StockDocuments, but retained it in StepItemListCalculations. This refines when recalculations for NetAmount, TotalAmount, and TaxAmount are triggered, likely to improve calculation accuracy and performance.