### PR TITLE
#IRP-763 Enhance CloseSession to handle postponed receipts

### DIFF
--- a/IRP/src/DataProcessors/PointOfSale/Forms/Form/Module.bsl
+++ b/IRP/src/DataProcessors/PointOfSale/Forms/Form/Module.bsl
@@ -182,10 +182,21 @@ EndProcedure
 
 &AtClient
 Procedure CloseSession(Command)
-	CountPostponedReceipts = GetCountPostponedReceipts(Object.ConsolidatedRetailSales);
-	If CountPostponedReceipts > 0 Then
-		OpenPostponedReceipt(Command);
-		Return;
+	
+	If ValueIsFilled(Object.ConsolidatedRetailSales) Then
+		CountPostponedReceipts = GetCountPostponedReceipts(Object.ConsolidatedRetailSales);
+		If CountPostponedReceipts > 0 Then
+			PostponeOptions = CommonFunctionsServer.GetAttributesFromRef(Workstation, "PostponeWithReserve, PostponeWithoutReserve");
+			If Not PostponeOptions.PostponeWithReserve And Not PostponeOptions.PostponeWithoutReserve Then
+				NumberOfCanceled = CancelingPostponedReceipts(Object.ConsolidatedRetailSales);
+				If NumberOfCanceled > 0 Then
+					CommonFunctionsClientServer.ShowUsersMessage(StrTemplate(R().POS_CancelPostponed, NumberOfCanceled));
+				EndIf;
+			Else
+				OpenPostponedReceipt(Command);
+				Return;
+			EndIf;
+		EndIf;
 	EndIf;
 	
 	FormParameters = New Structure();


### PR DESCRIPTION
Updated the CloseSession procedure to check for filled ConsolidatedRetailSales and handle postponed receipts more robustly. Now, if no postpone options are available, it cancels postponed receipts and notifies the user; otherwise, it opens the postponed receipt as before.