### PR TITLE
#IRP-798 Incorrect movements in JE for DtCrNote

### DIFF
--- a/IRP/src/Documents/DebitCreditNote/ManagerModule.bsl
+++ b/IRP/src/Documents/DebitCreditNote/ManagerModule.bsl
@@ -95,6 +95,7 @@ Function GetAdditionalQueryParameters(Ref)
 	ArrayOfReceivable.Add(Enums.DebtTypes.TransactionCustomer);
 	ArrayOfReceivable.Add(Enums.DebtTypes.OtherPartnerReceivable);
 	ArrayOfReceivable.Add(Enums.DebtTypes.EmployeeReceivable);
+	ArrayOfReceivable.Add(Enums.DebtTypes.EmployeePayable);
 	StrParams.Insert("ArrayOfReceivable", ArrayOfReceivable);
 	
 	// Payable
@@ -102,7 +103,6 @@ Function GetAdditionalQueryParameters(Ref)
 	ArrayOfPayable.Add(Enums.DebtTypes.AdvanceCustomer);
 	ArrayOfPayable.Add(Enums.DebtTypes.TransactionVendor);
 	ArrayOfPayable.Add(Enums.DebtTypes.OtherPartnerPayable);
-	ArrayOfPayable.Add(Enums.DebtTypes.EmployeePayable);
 	StrParams.Insert("ArrayOfPayable", ArrayOfPayable);
 	
 	Return StrParams;


### PR DESCRIPTION
The entries for T1040T_AccountingAmounts were mixed up. This has been corrected.